### PR TITLE
Fallback index metamethod

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,20 +14,24 @@
 * Breaking Change: Removed `Class<T>::addCFunction`, it was just an alias for `Class<T>::addFunction`.
 * Breaking Change: Removed `Class<T>::addStaticCFunction`, it was just an alias for `Class<T>::addStaticFunction`.
 * Allow specifying a non virtual base class method when declaring class members (functions or variables) not exposed in the inherited class.
-* Allow using capturing lambdas in `Namespace::addFunction` and `Class<T>::addFunction`.
+* Allow using capturing lambdas in `Namespace::addFunction`, `Namespace::addProperty`, `Class<T>::addFunction`, `Class<T>::addStaticFunction`, `Class<T>::addProperty` and `Class<T>::addStaticProperty`.
 * Added support for specifying factory functor in `Class<T>::addConstructor` to do placement new of the object instance.
-* Allow using capturing lambdas in `Namespace::addProperty`.
 * Added `Namespace::addVariable` to allow adding a modifiable value by copy into the namespace without incurring in function calls or metatables generation.
 * Added `getNamespaceFromStack` function to construct a namespace object from a table on the stack.
+* Added `registerMainThread` function especially useful when using lua 5.1 to register the main lua thread.
 * Added `std::shared_ptr` support for types intrusively deriving from `std::enable_shared_from_this`.
 * Added `Class<T>::addFunction` overload taking a `lua_CFunction` as if it were a member.
+* Added `Class<T>::addIndexMetaMethod` to allow register `__index` metamethod fallback on a registered class.
+* Added `Class<T>::addNewIndexMetaMethod` to allow register `__newindex` metamethod fallback on a registered class.
 * Added `LuaRef::isValid` to check when the reference is a LUA_NOREF.
+* Added `LuaRef::isCallable` to check when the reference is a function or has a `__call` metamethod.
 * Added `LuaException::state` to return the `lua_State` associated with the exception.
 * Added support for `std::byte` as stack value type.
 * Added support for `std::string_view` as stack value type.
 * Added support for `std::tuple` as stack value type.
 * Added support for `std::optional` as stack value type.
 * Added support for `std::set` as stack value type by using `LuaBridge/Set.h`.
+* Added support to `LuaRef` for being hashed with `std::hash` (`LuaRef` properly usable in `std::unordered_map`).
 * Added single header amalgamated distribution file, to simplify including in projects.
 * Added more asserts for functions and property names.
 * Renamed `luabridge::Nil` to `luabridge::LuaNil` to allow including LuaBridge in Obj-C sources.
@@ -39,10 +43,12 @@
 * Changed all generic functions in `LuaRef` and `TableItem` to accept arguments by const reference instead of by copy.
 * Fixed issue when `LuaRef::cast<>` fails with exceptions enabled, popping from the now empty stack could trigger the panic handler twice.
 * Fixed unaligned access in user allocated member pointers in 64bit machines reported by ASAN.
+* Fixed access of `LuaRef` in garbage collected `lua_thread`.
 * Included testing against Luau VM
 * Bumped lua 5.2.x in unit tests from lua 5.2.0 to 5.2.4.
 * Bumped lua 5.4.x in unit tests from lua 5.4.1 to 5.4.4.
 * Run against lua 5.3.6 and 5.4.4 in unit tests.
+* Run against Luau and LuaJIT in unit tests.
 * Converted the manual from html to markdown.
 * Small improvements to code and doxygen comments readability.
 

--- a/Manual.md
+++ b/Manual.md
@@ -672,7 +672,7 @@ luabridge::getGlobalNamespace (L)
       })
       .addNewIndexMetaMethod ([](FlexibleClass& self, const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L)
       {
-        self.properties.emplace (std::make_pair (eyk, value))
+        self.properties.emplace (std::make_pair (key, value))
         return luabridge::LuaRef (L, luabridge::LuaNil ());
       })
     .endClass ()

--- a/Source/LuaBridge/detail/CFunctions.h
+++ b/Source/LuaBridge/detail/CFunctions.h
@@ -163,7 +163,8 @@ inline int newindex_metamethod(lua_State* L, bool pushSelf)
 
             lua_pop(L, 1); // Stack: mt
             lua_pop(L, 1); // Stack: -
-            return luaL_error (L, "No writable member '%s'", lua_tostring (L, 2));
+            luaL_error(L, "No writable member '%s'", lua_tostring(L, 2));
+            return 0;
         }
 
         assert(lua_istable(L, -1)); // Stack: mt, parent mt

--- a/Source/LuaBridge/detail/CFunctions.h
+++ b/Source/LuaBridge/detail/CFunctions.h
@@ -74,11 +74,25 @@ inline int index_metamethod(lua_State* L)
 
         if (lua_isnil(L, -1)) // Stack: mt, nil
         {
-            lua_remove(L, -2); // Stack: nil
+            lua_pop(L, 1); // Stack: mt
+            lua_rawgetp(L, -1, getIndexFallbackKey()); // Stack: mt, ifb (may be nil)
+            lua_remove(L, -2); // Stack: ifb
+            if (lua_iscfunction(L, -1))
+            {
+                lua_pushvalue(L, 1); // Stack: ifb, arg1
+                lua_pushvalue(L, 2); // Stack: ifb, arg2
+                lua_call(L, 2, 1); // Stack: ifbresult
+            }
+            else
+            {
+                lua_pop(L, 1);
+                lua_pushnil(L);
+            }
+
             return 1;
         }
 
-        // Removethe  metatable and repeat the search in the parent one.
+        // Remove the metatable and repeat the search in the parent one.
         assert(lua_istable(L, -1)); // Stack: mt, parent mt
         lua_remove(L, -2); // Stack: parent mt
     }
@@ -136,12 +150,25 @@ inline int newindex_metamethod(lua_State* L, bool pushSelf)
 
         if (lua_isnil(L, -1)) // Stack: mt, nil
         {
+            lua_pop(L, 1); // Stack: mt
+            lua_rawgetp(L, -1, getNewIndexFallbackKey()); // Stack: mt, nifb (may be nil)
+            if (lua_iscfunction(L, -1))
+            {
+                lua_pushvalue(L, 1); // stack: nifb, arg1
+                lua_pushvalue(L, 2); // stack: nifb, arg2
+                lua_pushvalue(L, 3); // stack: nifb, arg3
+                lua_call(L, 3, 1); // stack: nifbresult
+                return 0;
+            }
+
+            lua_pop(L, 1); // Stack: mt
             lua_pop(L, 1); // Stack: -
-            luaL_error(L, "No writable member '%s'", lua_tostring(L, 2));
+            return luaL_error (L, "No writable member '%s'", lua_tostring (L, 2));
         }
 
         assert(lua_istable(L, -1)); // Stack: mt, parent mt
         lua_remove(L, -2); // Stack: parent mt
+
         // Repeat the search in the parent
     }
 

--- a/Source/LuaBridge/detail/ClassInfo.h
+++ b/Source/LuaBridge/detail/ClassInfo.h
@@ -116,5 +116,22 @@ const void* getConstRegistryKey() noexcept
     return std::addressof(value);
 }
 
+//=================================================================================================
+/**
+ * The key of the index fall back in another metatable.
+ */
+inline const void* getIndexFallbackKey()
+{
+  return reinterpret_cast<void*>(0x81ca);
+}
+
+//=================================================================================================
+/**
+ * The key of the new index fall back in another metatable.
+ */
+inline const void* getNewIndexFallbackKey()
+{
+  return reinterpret_cast<void*>(0x8107);
+}
 } // namespace detail
 } // namespace luabridge

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -1135,6 +1135,104 @@ class Namespace : public detail::Registrar
 
             return *this;
         }
+
+        //=========================================================================================
+        /**
+         * @brief Add an index metamethod function fallback that is triggered when no result is found in functions, properties or any other members.
+         *
+         * Let the user define a fallback index (__index) metamethod at its level.
+         */
+        template <class Function, typename = std::enable_if_t<!std::is_pointer_v<Function> && detail::function_arity_v<Function> != 0>>
+        Class<T> addIndexMetaMethod(Function function)
+        {
+            using FnType = decltype(function);
+
+            using FirstArg = detail::function_argument_t<0, Function>;
+            static_assert(std::is_same_v<std::decay_t<std::remove_pointer_t<FirstArg>>, T>);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            lua_newuserdata_aligned<FnType>(L, std::move(function)); // Stack: co, cl, st, function userdata (ud)
+            lua_pushcclosure_x(L, &detail::invoke_proxy_functor<FnType>, 1); // Stack: co, cl, st, function
+            lua_rawsetp(L, -3, detail::getIndexFallbackKey());
+
+            return *this;
+        }
+
+        Class<T>& addIndexMetaMethod(LuaRef (*idxf)(T&, const LuaRef&, lua_State*))
+        {
+            using FnType = decltype(idxf);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            lua_pushlightuserdata(L, reinterpret_cast<void*>(idxf)); // Stack: co, cl, st, function ptr
+            lua_pushcclosure_x(L, &detail::invoke_proxy_function<FnType>, 1); // Stack: co, cl, st, function
+            lua_rawsetp(L, -3, detail::getIndexFallbackKey());
+
+            return *this;
+        }
+
+        Class<T>& addIndexMetaMethod(LuaRef (T::* idxf)(const LuaRef&, lua_State*))
+        {
+            using MemFnPtr = decltype(idxf);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            new (lua_newuserdata_x<MemFnPtr>(L, sizeof(MemFnPtr))) MemFnPtr(idxf);
+            lua_pushcclosure_x(L, &detail::invoke_member_function<MemFnPtr, T>, 1);
+            lua_rawsetp(L, -3, detail::getIndexFallbackKey());
+
+            return *this;
+        }
+
+        //=========================================================================================
+        /**
+         * @brief Add an insert index metamethod function fallback that is triggered when no result is found in functions, properties or any other members.
+         *
+         * Let the user define a fallback insert index (___newindex) metamethod at its level.
+         */
+        template <class Function, typename = std::enable_if_t<!std::is_pointer_v<Function> && detail::function_arity_v<Function> != 0>>
+        Class<T> addNewIndexMetaMethod(Function function)
+        {
+            using FnType = decltype(function);
+
+            using FirstArg = detail::function_argument_t<0, Function>;
+            static_assert(std::is_same_v<std::decay_t<std::remove_pointer_t<FirstArg>>, T>);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            lua_newuserdata_aligned<FnType>(L, std::move(function)); // Stack: co, cl, st, function userdata (ud)
+            lua_pushcclosure_x(L, &detail::invoke_proxy_functor<FnType>, 1); // Stack: co, cl, st, function
+            lua_rawsetp(L, -3, detail::getNewIndexFallbackKey());
+
+            return *this;
+        }
+
+        Class<T>& addNewIndexMetaMethod(LuaRef (*idxf)(T&, const LuaRef&, const LuaRef&, lua_State*))
+        {
+            using FnType = decltype(idxf);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            lua_pushlightuserdata(L, reinterpret_cast<void*>(idxf)); // Stack: co, cl, st, function ptr
+            lua_pushcclosure_x(L, &detail::invoke_proxy_function<FnType>, 1); // Stack: co, cl, st, function
+            lua_rawsetp(L, -3, detail::getNewIndexFallbackKey());
+
+            return *this;
+        }
+
+        Class<T>& addNewIndexMetaMethod(LuaRef (T::* idxf)(const LuaRef&, const LuaRef&, lua_State*))
+        {
+            using MemFnPtr = decltype(idxf);
+
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            new (lua_newuserdata_x<MemFnPtr>(L, sizeof(MemFnPtr))) MemFnPtr(idxf);
+            lua_pushcclosure_x(L, &detail::invoke_member_function<MemFnPtr, T>, 1);
+            lua_rawsetp(L, -3, detail::getNewIndexFallbackKey());
+
+            return *this;
+        }
     };
 
     class Table : public detail::Registrar

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -2280,7 +2280,7 @@ luabridge::LuaRef OverridableX::indexMetaMethod(const luabridge::LuaRef& key, lu
 
 luabridge::LuaRef newIndexMetaMethodFunction(OverridableX& x, const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L)
 {
-    x.data.try_emplace(key, value);
+    x.data.emplace(std::make_pair(key, value));
     return value;
 }
 
@@ -2393,7 +2393,7 @@ TEST_F(ClassTests, NewIndexFallbackMetaMethodFreeFunctor)
             lua_pushnil(L);
 
         auto v = luabridge::LuaRef::fromStack(L);
-        x.data.try_emplace(key, v);
+        x.data.emplace(std::make_pair(key, v));
         return v;
     };
 

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <unordered_map>
 
 struct ClassTests : TestBase
 {
@@ -2240,4 +2241,171 @@ TEST_F(ClassTests, NilCanBeConvertedToNullptrButNotToReference)
     EXPECT_FALSE(runLua("TakeReference(nil)"));
 #endif
     EXPECT_FALSE(called);
+}
+
+namespace {
+struct OverridableX
+{
+    luabridge::LuaRef indexMetaMethod(const luabridge::LuaRef& key, lua_State* L);
+    luabridge::LuaRef newIndexMetaMethod(const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L);
+
+    std::unordered_map<luabridge::LuaRef, luabridge::LuaRef> data;
+};
+
+luabridge::LuaRef indexMetaMethodFunction(OverridableX& x, const luabridge::LuaRef& key, lua_State* L)
+{
+    std::error_code ec;
+
+    if (key.tostring() == "xyz")
+    {
+        if (!luabridge::push(L, "123", ec))
+            lua_pushnil(L);
+    }
+    else
+    {
+        auto it = x.data.find(key);
+        if (it != x.data.end())
+            return it->second;
+
+        lua_pushnil(L);
+    }
+
+    return luabridge::LuaRef::fromStack(L);
+}
+
+luabridge::LuaRef OverridableX::indexMetaMethod(const luabridge::LuaRef& key, lua_State* L)
+{
+    return indexMetaMethodFunction(*this, key, L);
+}
+
+luabridge::LuaRef newIndexMetaMethodFunction(OverridableX& x, const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L)
+{
+    x.data.try_emplace(key, value);
+    return value;
+}
+
+luabridge::LuaRef OverridableX::newIndexMetaMethod(const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L)
+{
+    return newIndexMetaMethodFunction(*this, key, value, L);
+}
+} // namespace
+
+TEST_F(ClassTests, IndexFallbackMetaMethodMemberFptr)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(&OverridableX::indexMetaMethod)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("result = x.xyz");
+    ASSERT_EQ("123", result().cast<std::string_view>());
+}
+
+TEST_F(ClassTests, IndexFallbackMetaMethodFunctionPtr)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(&indexMetaMethodFunction)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("result = x.xyz");
+    ASSERT_EQ("123", result().cast<std::string_view>());
+}
+
+TEST_F(ClassTests, IndexFallbackMetaMethodFreeFunctor)
+{
+    std::string capture = "123";
+
+    auto indexMetaMethod = [&capture](OverridableX&, luabridge::LuaRef key, lua_State* L) -> luabridge::LuaRef
+    {
+        std::error_code ec;
+
+        if (key.tostring() == "xyz")
+        {
+            if (!luabridge::push(L, capture + "123", ec))
+                lua_pushnil(L);
+        }
+        else
+        {
+            if (!luabridge::push(L, 456, ec))
+                lua_pushnil(L);
+        }
+
+        return luabridge::LuaRef::fromStack(L);
+    };
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(indexMetaMethod)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("result = x.xyz");
+    ASSERT_EQ("123123", result().cast<std::string_view>());
+}
+
+TEST_F(ClassTests, NewIndexFallbackMetaMethodMemberFptr)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(&OverridableX::indexMetaMethod)
+            .addNewIndexMetaMethod(&OverridableX::newIndexMetaMethod)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("x.qwertyuiop = 123; result = x.qwertyuiop");
+    ASSERT_EQ(123, result().cast<int>());
+}
+
+TEST_F(ClassTests, NewIndexFallbackMetaMethodFunctionPtr)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(&indexMetaMethodFunction)
+            .addNewIndexMetaMethod(&newIndexMetaMethodFunction)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("x.qwertyuiop = 123; result = x.qwertyuiop");
+    ASSERT_EQ(123, result().cast<int>());
+}
+
+TEST_F(ClassTests, NewIndexFallbackMetaMethodFreeFunctor)
+{
+    int capture = 123;
+
+    auto newIndexMetaMethod = [&capture](OverridableX& x, const luabridge::LuaRef& key, const luabridge::LuaRef& value, lua_State* L) -> luabridge::LuaRef
+    {
+        std::error_code ec;
+        if (!luabridge::push(L, capture + value.cast<int>(), ec))
+            lua_pushnil(L);
+
+        auto v = luabridge::LuaRef::fromStack(L);
+        x.data.try_emplace(key, v);
+        return v;
+    };
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<OverridableX>("X")
+            .addIndexMetaMethod(&indexMetaMethodFunction)
+            .addNewIndexMetaMethod(newIndexMetaMethod)
+        .endClass();
+
+    OverridableX x;
+    luabridge::setGlobal(L, &x, "x");
+
+    runLua("x.qwertyuiop = 123; result = x.qwertyuiop");
+    ASSERT_EQ(246, result().cast<int>());
 }

--- a/Tests/Source/TestBase.h
+++ b/Tests/Source/TestBase.h
@@ -1,4 +1,5 @@
 // https://github.com/kunitoki/LuaBridge3
+// Copyright 2022, Lucio Asnaghi
 // Copyright 2019, Dmitry Tarakanov
 // Copyright 2012, Vinnie Falco <vinnie.falco@gmail.com>
 // Copyright 2007, Nathan Reed
@@ -48,7 +49,7 @@ inline int traceback(lua_State* L)
     lua_pushvalue(L, 1);
     lua_pushinteger(L, 2);
     lua_call(L, 2, 1);
-    
+
     lua_getglobal(L, "print");
     if (!lua_isfunction(L, -1))
     {
@@ -58,7 +59,7 @@ inline int traceback(lua_State* L)
 
     lua_pushvalue(L, 1);
     lua_call(L, 1, 0);
-    
+
     return 1;
 }
 
@@ -66,14 +67,14 @@ inline int traceback(lua_State* L)
 inline int luaL_loadstring(lua_State *L, const char *s)
 {
     FFlag::LuauActivateBeforeExec.value = true;
-    
+
     std::size_t bytecodeSize = 0;
 
     auto bytecode = std::shared_ptr<char>(
         luau_compile(s, std::strlen(s), nullptr, &bytecodeSize),
         [](char* x) { std::free(x); }
     );
-    
+
     return luau_load(L, "code", bytecode.get(), bytecodeSize, 0);
 }
 #endif
@@ -201,7 +202,7 @@ struct TestBase : public ::testing::Test
             lua_pushnil(L);
         }
     }
-    
+
     void printStack() const
     {
         std::cerr << "===== Stack =====\n";

--- a/Tests/Source/UnorderedMapTests.cpp
+++ b/Tests/Source/UnorderedMapTests.cpp
@@ -24,7 +24,6 @@ struct Data
 } // namespace
 
 namespace std {
-
 template<>
 struct hash<Data>
 {
@@ -33,16 +32,6 @@ struct hash<Data>
         return 0; // Don't care about hash collisions
     }
 };
-
-template<>
-struct hash<::luabridge::LuaRef>
-{
-    size_t operator()(const ::luabridge::LuaRef& value) const
-    {
-        return 0; // Don't care about hash collisions
-    }
-};
-
 } // namespace std
 
 TEST_F(UnorderedMapTests, LuaRef)
@@ -51,13 +40,16 @@ TEST_F(UnorderedMapTests, LuaRef)
         runLua("result = {[false] = true, a = 'abc', [1] = 5, [3.14] = -1.1}");
 
         using Map = std::unordered_map<luabridge::LuaRef, luabridge::LuaRef>;
-        Map expected{
-            {luabridge::LuaRef(L, false), luabridge::LuaRef(L, true)},
-            {luabridge::LuaRef(L, 'a'), luabridge::LuaRef(L, "abc")},
-            {luabridge::LuaRef(L, 1), luabridge::LuaRef(L, 5)},
-            {luabridge::LuaRef(L, 3.14), luabridge::LuaRef(L, -1.1)},
+
+        Map expected {
+            { luabridge::LuaRef(L, false), luabridge::LuaRef(L, true) },
+            { luabridge::LuaRef(L, 'a'), luabridge::LuaRef(L, "abc") },
+            { luabridge::LuaRef(L, 1), luabridge::LuaRef(L, 5) },
+            { luabridge::LuaRef(L, 3.14), luabridge::LuaRef(L, -1.1) },
         };
+
         Map actual = result();
+
         ASSERT_EQ(expected, actual);
         ASSERT_EQ(expected, result<Map>());
     }


### PR DESCRIPTION
Allows to fallback on not found properties in luabridge classes both for __index and __newindex metamethods. This makes it possible to specify fallback methods when accessing a luabridge object on non existing properties.