### PR TITLE
Improve coroutines support

### DIFF
--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -1162,6 +1162,23 @@ public:
 
     //=============================================================================================
     /**
+     * @brief Move the reference to the a separate coroutine (lua_State).
+     */
+    void moveTo(lua_State* newL)
+    {
+        push();
+
+        lua_xmove(m_L, newL, 1);
+
+        if (m_ref != LUA_NOREF)
+            luaL_unref(m_L, LUA_REGISTRYINDEX, m_ref);
+
+        m_L = newL;
+        m_ref = luaL_ref(newL, LUA_REGISTRYINDEX);
+    }
+
+    //=============================================================================================
+    /**
      * @brief Access a table value using a key.
      *
      * This invokes metamethods.

--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -1162,7 +1162,7 @@ public:
 
     //=============================================================================================
     /**
-     * @brief Move the reference to the a separate coroutine (lua_State).
+     * @brief Move the reference to a separate coroutine (lua_State).
      */
     void moveTo(lua_State* newL)
     {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set (LUABRIDGE_TEST_SOURCE_FILES
   Source/AmalgamateTests.cpp
   Source/ArrayTests.cpp
   Source/ClassTests.cpp
+  Source/CoroutineTests.cpp
   Source/ExceptionTests.cpp
   Source/IssueTests.cpp
   Source/IteratorTests.cpp

--- a/Tests/Source/CoroutineTests.cpp
+++ b/Tests/Source/CoroutineTests.cpp
@@ -1,0 +1,163 @@
+// https://github.com/kunitoki/LuaBridge3
+// Copyright 2023, Lucio Asnaghi
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+
+struct CoroutineTests : TestBase
+{
+};
+
+TEST_F(CoroutineTests, LuaRefAsThread)
+{
+    [[maybe_unused]] lua_State* thread = lua_newthread(L);
+
+    auto x = luabridge::LuaRef::fromStack(L, 1);
+    EXPECT_TRUE(x.isThread());
+    EXPECT_EQ(L, x.unsafe_cast<lua_State*>());
+}
+
+TEST_F(CoroutineTests, LuaRefGlobal)
+{
+    lua_State* thread = lua_newthread(L);
+
+    if (!runLua("x = 42", thread))
+    {
+        FAIL();
+        return;
+    }
+
+    luabridge::LuaRef x = luabridge::getGlobal(thread, "x");
+    EXPECT_EQ(thread, x.state());
+    EXPECT_EQ(42, x.unsafe_cast<int>());
+
+    luabridge::LuaRef y = luabridge::getGlobal(L, "x");
+    EXPECT_EQ(L, y.state());
+    EXPECT_EQ(42, y.unsafe_cast<int>());
+}
+
+TEST_F(CoroutineTests, LuaRefLocal)
+{
+    lua_State* thread = lua_newthread(L);
+
+    if (!runLua("local x = 42", thread))
+    {
+        FAIL();
+        return;
+    }
+
+    luabridge::LuaRef x = luabridge::getGlobal(thread, "x");
+    EXPECT_EQ(thread, x.state());
+    EXPECT_FALSE(!!x.cast<int>());
+
+    luabridge::LuaRef y = luabridge::getGlobal(L, "x");
+    EXPECT_EQ(L, y.state());
+    EXPECT_FALSE(!!y.cast<int>());
+}
+
+TEST_F(CoroutineTests, LuaRefMove)
+{
+    lua_State* thread1 = lua_newthread(L);
+    lua_State* thread2 = lua_newthread(L);
+
+    EXPECT_TRUE(luabridge::push(thread1, 42));
+    luabridge::LuaRef x = *luabridge::get<luabridge::LuaRef>(thread1, 1);
+    EXPECT_EQ(thread1, x.state());
+    EXPECT_EQ(42, x.unsafe_cast<int>());
+
+    EXPECT_TRUE(luabridge::push(thread2, 1337));
+    luabridge::LuaRef y = *luabridge::get<luabridge::LuaRef>(thread2, 1);
+    EXPECT_EQ(thread2, y.state());
+    EXPECT_EQ(1337, y.unsafe_cast<int>());
+
+    x.moveTo(thread2);
+    EXPECT_EQ(thread2, x.state());
+    EXPECT_EQ(42, x.unsafe_cast<int>());
+
+    y = x;
+    EXPECT_EQ(thread2, y.state());
+    EXPECT_EQ(42, y.unsafe_cast<int>());
+}
+
+TEST_F(CoroutineTests, ThreadedRegistration)
+{
+    using namespace luabridge;
+
+    struct SomeClass
+    {
+        SomeClass(int x) : value(x) {}
+
+        int value = 0;
+    };
+
+    // Create a thread
+    lua_State* thread2 = lua_newthread(L);
+    lua_State* thread1 = lua_newthread(L);
+
+    {
+        auto result = luaL_loadstring(thread1, "x = SomeClass(42)");
+        ASSERT_EQ(LUABRIDGE_LUA_OK, result);
+    }
+
+    // Build the thread local table
+    lua_newtable(thread1);
+    luabridge::getNamespaceFromStack(thread1)
+        .beginClass<SomeClass>("SomeClass")
+            .addConstructor<void (*)(int)>()
+            .addProperty("value", &SomeClass::value)
+        .endClass();
+
+    auto env = luaL_ref(thread1, LUA_REGISTRYINDEX);
+    lua_rawgeti(thread1, LUA_REGISTRYINDEX, env);
+
+#if LUABRIDGEDEMO_LUAU || LUABRIDGEDEMO_LUAJIT || LUABRIDGEDEMO_LUA_VERSION == 501
+    lua_setfenv(thread1, 1);
+#else
+    auto upvalue = lua_setupvalue(thread1, -2, 1);
+    ASSERT_STREQ("_ENV", upvalue);
+#endif
+
+    ASSERT_EQ(LUA_TFUNCTION, lua_type(thread1, -1));
+    auto scriptRef = luaL_ref(thread1, LUA_REGISTRYINDEX);
+    lua_rawgeti(thread1, LUA_REGISTRYINDEX, scriptRef);
+
+    {
+#if LUABRIDGEDEMO_LUAJIT || LUABRIDGEDEMO_LUA_VERSION == 501
+        auto result = lua_resume(thread1, 0);
+#elif LUABRIDGEDEMO_LUAU || LUABRIDGEDEMO_LUA_VERSION < 504
+        auto result = lua_resume(thread1, nullptr, 0);
+#else
+        int nresults = 0;
+        auto result = lua_resume(thread1, nullptr, 0, &nresults);
+#endif
+
+        ASSERT_EQ(LUABRIDGE_LUA_OK, result);
+    }
+
+    lua_rawgeti(thread1, LUA_REGISTRYINDEX, env);
+    luabridge::LuaRef envx = luabridge::LuaRef::fromStack(thread1, 1);
+    luabridge::LuaRef x0 = envx["x"];
+    EXPECT_EQ(thread1, x0.state());
+    EXPECT_TRUE(!!x0.cast<SomeClass>());
+    EXPECT_EQ(42, x0.unsafe_cast<SomeClass>().value);
+
+    // SomeClass x should not "leak" into globals of any thread/state
+    luabridge::LuaRef x1 = luabridge::getGlobal(L, "x");
+    EXPECT_EQ(L, x1.state());
+    EXPECT_FALSE(!!x1.cast<SomeClass>());
+
+    luabridge::LuaRef x2 = luabridge::getGlobal(thread1, "x");
+    EXPECT_EQ(thread1, x2.state());
+    EXPECT_FALSE(!!x2.cast<SomeClass>());
+
+    luabridge::LuaRef x3 = luabridge::getGlobal(thread2, "x");
+    EXPECT_EQ(thread2, x3.state());
+    EXPECT_FALSE(!!x3.cast<SomeClass>());
+
+    // Another coroutine will see no luabridge registration
+#if LUABRIDGE_HAS_EXCEPTIONS
+    EXPECT_THROW(runLua("x = SomeClass(42)", thread2), std::exception);
+#else
+    EXPECT_FALSE(runLua("x = SomeClass(42)", thread2));
+#endif
+}

--- a/Tests/Source/IssueTests.cpp
+++ b/Tests/Source/IssueTests.cpp
@@ -223,18 +223,18 @@ TEST_F(IssueTests, IssueMainThread)
         .beginClass<SomeClass>("SomeClass")
         .addConstructor<void (*)(lua_State*)>()
         .addFunction("SomeMember", &SomeClass::SomeMember)
-        .addProperty("SomeMemberOveride", &SomeClass::override_)
+        .addProperty("SomeMemberOverride", &SomeClass::override_)
         .endClass();
 
     const char* source = R"(
         function test()
             c:SomeMember()
-            c.SomeMemberOveride = MyHandler
+            c.SomeMemberOverride = MyHandler
             c:SomeMember()
             --This is pretty cool too!
-            c:SomeMemberOveride()
+            c:SomeMemberOverride()
             --Revert to C++ version
-            c.SomeMemberOveride = nil
+            c.SomeMemberOverride = nil
             c:SomeMember()
             return
         end

--- a/Tests/Source/IteratorTests.cpp
+++ b/Tests/Source/IteratorTests.cpp
@@ -36,6 +36,8 @@ TEST_F(IteratorTests, DictionaryIteration)
 
     for (luabridge::Iterator iterator(result()); !iterator.isNil(); ++iterator)
     {
+        EXPECT_EQ(L, iterator.state());
+
         actual.emplace(iterator.key(), iterator.value());
     }
 
@@ -77,6 +79,8 @@ TEST_F(IteratorTests, SequenceIteration)
 
     for (luabridge::Iterator iterator(result()); !iterator.isNil(); ++iterator)
     {
+        EXPECT_EQ(L, iterator.state());
+
         actual.emplace(iterator.key(), iterator.value());
     }
 


### PR DESCRIPTION
- Added `LuaRef::moveTo` to move values across coroutines (lua threads)