### PR TITLE
Support multiple return values

### DIFF
--- a/Source/LuaBridge/detail/CFunctions.h
+++ b/Source/LuaBridge/detail/CFunctions.h
@@ -542,7 +542,7 @@ struct function
         if (! result)
             raise_lua_error(L, "%s", result.message().c_str());
 
-        return 1;
+        return result.num_args();
     }
 
     template <class T, class F>
@@ -569,7 +569,7 @@ struct function
         if (! result)
             raise_lua_error(L, "%s", result.message().c_str());
 
-        return 1;
+        return result.num_args();
     }
 };
 

--- a/Source/LuaBridge/detail/Result.h
+++ b/Source/LuaBridge/detail/Result.h
@@ -18,6 +18,7 @@ struct Result
 
     Result(std::error_code ec) noexcept
         : m_ec(ec)
+        , m_nargs(1)
     {
     }
 
@@ -46,8 +47,19 @@ struct Result
         return m_ec.message();
     }
 
+    inline int num_args() const
+    {
+        return m_nargs;
+	}
+
+	inline void num_args(int nargs)
+	{
+        m_nargs = nargs;
+	}
+
 private:
     std::error_code m_ec;
+    int m_nargs = 1;
 };
 
 //=================================================================================================


### PR DESCRIPTION
Sometimes you might want to push multiple values for a type.

For example when pushing all values of a variant type or std::pair. Currently it's done by pushing them in a table.

But in my case I don't want a table to return, I want each value separately in Lua.

```C++
[[nodiscard]] static Result push(lua_State* L, Type const& e)
{
	// push a value
	// push another value
	Result r;
	r.num_args(2); // We pushed two values so set it to 2
	return r;
}
```

PR is just an example. If you like this idea you could maybe implement it.