### PR TITLE
Disallow metamethods in luabridge registered classes __index

### DIFF
--- a/Source/LuaBridge/detail/CFunctions.h
+++ b/Source/LuaBridge/detail/CFunctions.h
@@ -111,6 +111,14 @@ inline int index_metamethod(lua_State* L)
     lua_getmetatable(L, 1); // Stack: class/const table (mt)
     LUABRIDGE_ASSERT(lua_istable(L, -1));
 
+    // Protect internal meta methods
+    const auto name = std::string_view(lua_tostring(L, 2));
+    if (name.size() > 2 && name[0] == '_' && name[1] == '_')
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+
     for (;;)
     {
         lua_pushvalue(L, 2); // Stack: mt, field name

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -2051,6 +2051,44 @@ TEST_F(ClassMetaMethods, __gcForbidden)
 }
 #endif
 
+TEST_F(ClassMetaMethods, metamethodsShouldNotBePartOfClassInstances)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+            .addConstructor<void (*)(int)>()
+        .endClass();
+
+#if LUABRIDGE_HAS_EXCEPTIONS
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__gc()"));
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__gc()"));
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__index()"));
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__index()"));
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__newindex()"));
+    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__newindex()"));
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__gc"));
+    EXPECT_TRUE(result().isNil());
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__index"));
+    EXPECT_TRUE(result().isNil());
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__newindex"));
+    EXPECT_TRUE(result().isNil());
+#else
+    EXPECT_FALSE(runLua("local x = Int(1); x.__gc()"));
+    EXPECT_FALSE(runLua("local x = Int(1); x:__gc()"));
+    EXPECT_FALSE(runLua("local x = Int(1); x.__index()"));
+    EXPECT_FALSE(runLua("local x = Int(1); x:__index()"));
+    EXPECT_FALSE(runLua("local x = Int(1); x.__newindex()"));
+    EXPECT_FALSE(runLua("local x = Int(1); x:__newindex()"));
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__gc"));
+    EXPECT_TRUE(result().isNil());
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__index"));
+    EXPECT_TRUE(result().isNil());
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__newindex"));
+    EXPECT_TRUE(result().isNil());
+#endif
+}
+
 TEST_F(ClassMetaMethods, SimulateArray)
 {
     using ContainerType = std::vector<std::string>;

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -2032,8 +2032,7 @@ TEST_F(ClassMetaMethods, __newindex)
 
     luabridge::setGlobal(L, &t, "t");
 
-    runLua("t.a = 1\n"
-           "t ['b'] = 2");
+    runLua("t.a = 1; t['b'] = 2");
 
     ASSERT_EQ((std::map<std::string, int>{{"a", 1}, {"b", 2}}), t.map);
 }
@@ -2061,12 +2060,12 @@ TEST_F(ClassMetaMethods, metamethodsShouldNotBePartOfClassInstances)
         .endClass();
 
 #if LUABRIDGE_HAS_EXCEPTIONS
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__gc()"));
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__gc()"));
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__index()"));
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__index()"));
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x.__newindex()"));
-    ASSERT_ANY_THROW(runLua("local x = Int(1); x:__newindex()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__gc()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x:__gc()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__index()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x:__index()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__newindex()"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x:__newindex()"));
     EXPECT_TRUE(runLua("local x = Int(1); result = x.__gc"));
     EXPECT_TRUE(result().isNil());
     EXPECT_TRUE(runLua("local x = Int(1); result = x.__index"));
@@ -2086,6 +2085,26 @@ TEST_F(ClassMetaMethods, metamethodsShouldNotBePartOfClassInstances)
     EXPECT_TRUE(result().isNil());
     EXPECT_TRUE(runLua("local x = Int(1); result = x.__newindex"));
     EXPECT_TRUE(result().isNil());
+#endif
+}
+
+TEST_F(ClassMetaMethods, metamethodsShouldNotBeWritable)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+            .addConstructor<void (*)(int)>()
+        .endClass();
+
+#if LUABRIDGE_HAS_EXCEPTIONS
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__gc = function() end"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__index = function() end"));
+    EXPECT_ANY_THROW(runLua("local x = Int(1); x.__newindex = function() end"));
+#else
+    EXPECT_FALSE(runLua("local x = Int(1); x.__gc = function() end"));
+    EXPECT_FALSE(runLua("local x = Int(1); x.__index = function() end"));
+    EXPECT_FALSE(runLua("local x = Int(1); x.__newindex = function() end"));
 #endif
 }
 

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -2057,6 +2057,7 @@ TEST_F(ClassMetaMethods, metamethodsShouldNotBePartOfClassInstances)
     luabridge::getGlobalNamespace(L)
         .beginClass<Int>("Int")
             .addConstructor<void (*)(int)>()
+            .addFunction("__xyz", [](const Int*) {})
         .endClass();
 
 #if LUABRIDGE_HAS_EXCEPTIONS
@@ -2086,6 +2087,10 @@ TEST_F(ClassMetaMethods, metamethodsShouldNotBePartOfClassInstances)
     EXPECT_TRUE(runLua("local x = Int(1); result = x.__newindex"));
     EXPECT_TRUE(result().isNil());
 #endif
+
+    EXPECT_TRUE(runLua("local x = Int(1); x:__xyz()"));
+    EXPECT_TRUE(runLua("local x = Int(1); result = x.__xyz"));
+    EXPECT_TRUE(result().isFunction());
 }
 
 TEST_F(ClassMetaMethods, metamethodsShouldNotBeWritable)


### PR DESCRIPTION
This should not be allowed:

```lua
local x = MyClass()
x:__gc()
```
