### PR TITLE
Change to the correct past participle of 'cast'.

### DIFF
--- a/Source/LuaBridge/detail/Errors.h
+++ b/Source/LuaBridge/detail/Errors.h
@@ -67,7 +67,7 @@ struct ErrorCategory : std::error_category
             return "The native floating point can't fit inside a lua number";
 
         case ErrorCode::InvalidTypeCast:
-            return "The lua object can't be casted to desired type";
+            return "The lua object can't be cast to desired type";
 
         case ErrorCode::InvalidTableSizeInCast:
             return "The lua table has different size than expected";


### PR DESCRIPTION
This PR fixes a typo in one of the error messages. See [this explanation](https://writingexplained.org/cast-vs-casted) for more details.