### PR TITLE
Fix Node.js 12 deprecated actions

### DIFF
--- a/.github/workflows/amalgamate.yml
+++ b/.github/workflows/amalgamate.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,9 @@ jobs:
         submodules: true
 
     - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install ninja-build
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
- https://github.com/kunitoki/LuaBridge3/actions/runs/4585674844
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

- https://github.com/kunitoki/LuaBridge3/actions/runs/4585674841
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: seanmiddleditch/gha-setup-ninja@master. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.