### PR TITLE
Windows compilation fails without #define NOMINMAX

### DIFF
--- a/Source/LuaBridge/detail/LuaHelpers.h
+++ b/Source/LuaBridge/detail/LuaHelpers.h
@@ -551,23 +551,23 @@ constexpr bool is_integral_representable_by(T value)
             return true;
 
         if constexpr (std::is_unsigned_v<T>)
-            return value <= static_cast<T>(std::numeric_limits<U>::max());
+            return value <= static_cast<T>((std::numeric_limits<U>::max)());
         
-        return value >= static_cast<T>(std::numeric_limits<U>::min())
-            && static_cast<U>(value) <= std::numeric_limits<U>::max();
+        return value >= static_cast<T>((std::numeric_limits<U>::min)())
+            && static_cast<U>(value) <= (std::numeric_limits<U>::max)();
     }
 
     if constexpr (sizeof(T) < sizeof(U))
     {
-        return static_cast<U>(value) >= std::numeric_limits<U>::min()
-            && static_cast<U>(value) <= std::numeric_limits<U>::max();
+        return static_cast<U>(value) >= (std::numeric_limits<U>::min)()
+            && static_cast<U>(value) <= (std::numeric_limits<U>::max)();
     }
 
     if constexpr (std::is_unsigned_v<T>)
-        return value <= static_cast<T>(std::numeric_limits<U>::max());
+        return value <= static_cast<T>((std::numeric_limits<U>::max)());
 
-    return value >= static_cast<T>(std::numeric_limits<U>::min())
-        && value <= static_cast<T>(std::numeric_limits<U>::max());
+    return value >= static_cast<T>((std::numeric_limits<U>::min)())
+        && value <= static_cast<T>((std::numeric_limits<U>::max)());
 }
 
 template <class U = lua_Integer>
@@ -590,11 +590,11 @@ constexpr bool is_floating_point_representable_by(T value)
         return true;
 
     if constexpr (sizeof(T) < sizeof(U))
-        return static_cast<U>(value) >= -std::numeric_limits<U>::max()
-            && static_cast<U>(value) <= std::numeric_limits<U>::max();
+        return static_cast<U>(value) >= -(std::numeric_limits<U>::max)()
+            && static_cast<U>(value) <= (std::numeric_limits<U>::max)();
 
-    return value >= static_cast<T>(-std::numeric_limits<U>::max())
-        && value <= static_cast<T>(std::numeric_limits<U>::max());
+    return value >= static_cast<T>(-(std::numeric_limits<U>::max)())
+        && value <= static_cast<T>((std::numeric_limits<U>::max)());
 }
 
 template <class U = lua_Number>


### PR DESCRIPTION
LuaBridge fails to compile on Windows Visual Studio 2023 unless `NOMINMAX` is defined.

The Windows sdk has really stupid macro definitions for `min` and `max`. You can suppress them with `NOMINMAX`, but imo it is incumbent on libraries where possible to accommodate this, since the fix is so easy.

With `std::min(max)` you simply enclose it in parentheses. That is:

```c++
int x = std::min(a, b);
```

becomes

```c++
int x = (std::min)(a, b);
```

This PR applies similar parentheses to the calls in LuaHelper.h
