### PR TITLE
Add message to BadExpectedAccess.

### DIFF
--- a/Source/LuaBridge/detail/Expected.h
+++ b/Source/LuaBridge/detail/Expected.h
@@ -988,10 +988,15 @@ class BadExpectedAccess : public BadExpectedAccess<void>
 {
 public:
     explicit BadExpectedAccess(E error) noexcept(std::is_nothrow_constructible_v<E, E&&>)
-        : error_(std::move(error))
+        : msg_(error.message()), error_(std::move(error))
     {
     }
-
+   
+    const char* what() const throw() override
+    {
+        return msg_.c_str();
+    }
+   
     const E& error() const& noexcept
     {
         return error_;
@@ -1008,6 +1013,7 @@ public:
     }
 
 private:
+    std::string msg_;
     E error_;
 };
 #endif

--- a/Source/LuaBridge/detail/Expected.h
+++ b/Source/LuaBridge/detail/Expected.h
@@ -988,15 +988,10 @@ class BadExpectedAccess : public BadExpectedAccess<void>
 {
 public:
     explicit BadExpectedAccess(E error) noexcept(std::is_nothrow_constructible_v<E, E&&>)
-        : msg_(error.message()), error_(std::move(error))
+        : error_(std::move(error))
     {
     }
-   
-    const char* what() const throw() override
-    {
-        return msg_.c_str();
-    }
-   
+
     const E& error() const& noexcept
     {
         return error_;
@@ -1013,7 +1008,6 @@ public:
     }
 
 private:
-    std::string msg_;
     E error_;
 };
 #endif

--- a/Source/LuaBridge/detail/Expected.h
+++ b/Source/LuaBridge/detail/Expected.h
@@ -1286,7 +1286,7 @@ public:
     {
 #if LUABRIDGE_HAS_EXCEPTIONS
         if (!hasValue())
-            throw BadExpectedAccess<E>(error());
+            throw BadExpectedAccess<E>(error(), error().message());
 #endif
 
         return std::move(base_type::value());

--- a/Source/LuaBridge/detail/Expected.h
+++ b/Source/LuaBridge/detail/Expected.h
@@ -976,10 +976,11 @@ template <class E>
 class BadExpectedAccess;
 
 template <>
-class BadExpectedAccess<void> : public std::exception
+class BadExpectedAccess<void> : public std::runtime_error
 {
 public:
-    explicit BadExpectedAccess() noexcept
+    explicit BadExpectedAccess(const std::string& message) noexcept
+        : std::runtime_error(message)
     {
     }
 };
@@ -987,8 +988,8 @@ template <class E>
 class BadExpectedAccess : public BadExpectedAccess<void>
 {
 public:
-    explicit BadExpectedAccess(E error) noexcept(std::is_nothrow_constructible_v<E, E&&>)
-        : error_(std::move(error))
+    explicit BadExpectedAccess(E error,const std::string& message) noexcept(std::is_nothrow_constructible_v<E, E&&>)
+        : BadExpectedAccess<void>(message), error_(std::move(error))
     {
     }
 
@@ -1265,7 +1266,7 @@ public:
     {
 #if LUABRIDGE_HAS_EXCEPTIONS
         if (!hasValue())
-            throw BadExpectedAccess<E>(error());
+            throw BadExpectedAccess<E>(error(), error().message());
 #endif
 
         return base_type::value();
@@ -1275,7 +1276,7 @@ public:
     {
 #if LUABRIDGE_HAS_EXCEPTIONS
         if (!hasValue())
-            throw BadExpectedAccess<E>(error());
+            throw BadExpectedAccess<E>(error(), error().message());
 #endif
 
         return base_type::value();
@@ -1295,7 +1296,7 @@ public:
     {
 #if LUABRIDGE_HAS_EXCEPTIONS
         if (!hasValue())
-            throw BadExpectedAccess<E>(error());
+            throw BadExpectedAccess<E>(error(), error().message());
 #endif
         return std::move(base_type::value());
     }

--- a/Source/LuaBridge/detail/Expected.h
+++ b/Source/LuaBridge/detail/Expected.h
@@ -988,7 +988,7 @@ template <class E>
 class BadExpectedAccess : public BadExpectedAccess<void>
 {
 public:
-    explicit BadExpectedAccess(E error,const std::string& message) noexcept(std::is_nothrow_constructible_v<E, E&&>)
+    explicit BadExpectedAccess(E error, const std::string& message) noexcept(std::is_nothrow_constructible_v<E, E&&>)
         : BadExpectedAccess<void>(message), error_(std::move(error))
     {
     }


### PR DESCRIPTION
I've been using `Stack<>::get` to pull values off the Lua stack inside proxy constructors. When I pass in the wrong types, it is producing the generic error message `std::exception`. 

A way to fix this appears to be to implement the `what` method, so that's what this PR does. I am opening it as a draft for comment, because there may be ramifications I don't know about. I tried returning `error_.message().c_str()` but that produced a garbage error message. Hence the new `msg_` member variable.