### PR TITLE
add `throw_on_error` to Result class.

### DIFF
--- a/Source/LuaBridge/detail/Result.h
+++ b/Source/LuaBridge/detail/Result.h
@@ -48,7 +48,7 @@ struct Result
     
     void throw_on_error() const
     {
-        if (!*this)
+        if (m_ec)
             throw std::system_error(m_ec);
     }
 

--- a/Source/LuaBridge/detail/Result.h
+++ b/Source/LuaBridge/detail/Result.h
@@ -45,6 +45,12 @@ struct Result
     {
         return m_ec.message();
     }
+    
+    void throw_on_error() const
+    {
+        if (!*this)
+            throw std::system_error(m_ec);
+    }
 
 private:
     std::error_code m_ec;

--- a/Source/LuaBridge/detail/Result.h
+++ b/Source/LuaBridge/detail/Result.h
@@ -46,12 +46,14 @@ struct Result
         return m_ec.message();
     }
     
+#if LUABRIDGE_HAS_EXCEPTIONS
     void throw_on_error() const
     {
         if (m_ec)
             throw std::system_error(m_ec);
     }
-
+#endif
+    
 private:
     std::error_code m_ec;
 };


### PR DESCRIPTION
As discussed in #83 here is a `Result::throw_on_error` function to make for cleaner push values with exception handling.

Should the function be disabled if `LUABRIDGE_HAS_EXCEPTIONS` is false? Or perhaps removed altogether so that code that tries to call it won't compile if `LUABRIDGE_HAS_EXCEPTIONS` is false?
