### PR TITLE
fix Stack<std::set<K>>::get()

### DIFF
--- a/Source/LuaBridge/Set.h
+++ b/Source/LuaBridge/Set.h
@@ -49,7 +49,7 @@ struct Stack<std::set<K>>
     [[nodiscard]] static TypeResult<Type> get(lua_State* L, int index)
     {
         if (!lua_istable(L, index))
-            return makeUnexpected(makeErrorCode(ErrorCode::InvalidTypeCast));
+            return makeErrorCode(ErrorCode::InvalidTypeCast);
 
         const StackRestore stackRestore(L);
 
@@ -62,7 +62,7 @@ struct Stack<std::set<K>>
         {
             auto item = Stack<K>::get(L, -1);
             if (! item)
-                return makeUnexpected(makeErrorCode(ErrorCode::InvalidTypeCast));
+                return makeErrorCode(ErrorCode::InvalidTypeCast);
 
             set.emplace(*item);
             lua_pop(L, 1);


### PR DESCRIPTION
There is no conversion from Unexpected to TypeResult, so we just need to return std::error_code