### PR TITLE
fix static properties registrations for subsequent class registrations

### DIFF
--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -347,8 +347,12 @@ class Namespace : public detail::Registrar
             }
             else
             {
-                LUABRIDGE_ASSERT(lua_istable(L, -1)); // Stack: ns, st
+                LUABRIDGE_ASSERT(lua_istable(L, -1)); // Stack: ns, vst
                 ++m_stackSize;
+
+                lua_getmetatable(L, -1); // Stack: ns, vst, st
+                lua_insert(L, -2); // Stack: ns, st, vst
+                lua_pop(L, 1); // Stack: ns, st
 
                 // Map T back from its stored tables
 

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -1718,6 +1718,27 @@ TEST_F(ClassStaticProperties, FieldPointers_Overridden)
     ASSERT_EQ(7, Derived::staticData);
 }
 
+TEST_F(ClassStaticProperties, SubsequentRegistration)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .endClass()
+        .beginClass<Int>("Int")
+        .addStaticProperty("staticData", &Int::staticData, true)
+        .endClass();
+
+    Int::staticData = 10;
+
+    runLua("result = Int.staticData");
+    ASSERT_TRUE(result().isNumber());
+    ASSERT_EQ(10, result<int>());
+
+    runLua("Int.staticData = 20");
+    ASSERT_EQ(20, Int::staticData);
+}
+
 struct ClassMetaMethods : ClassTests
 {
 };


### PR DESCRIPTION
currently, for subsequent class registrations, Luabridge puts visible static table on stack instead of the static table (which is the metatable of visible static table). in this case, static properties registrations fail because visible static table doesn't contain the PropGet table.
this simple merge request fixes that (replaces visible static table with the static table for subsequent class registrations)