### PR TITLE
Proposed mods to `callWithHandler`

### DIFF
--- a/Source/LuaBridge/detail/Invoke.h
+++ b/Source/LuaBridge/detail/Invoke.h
@@ -180,7 +180,10 @@ LuaResult callWithHandler(const LuaRef& object, F&& errorHandler, Args&&... args
     const int stackTop = lua_gettop(L);
 
     if constexpr (isValidHandler)
-        detail::push_function(L, std::forward<F>(errorHandler), ""); // Stack: error handler (eh)
+    {
+       if (errorHandler)
+          detail::push_function(L, std::forward<F>(errorHandler), ""); // Stack: error handler (eh)
+    }
 
     object.push(); // Stack: eh, ref
 
@@ -199,11 +202,8 @@ LuaResult callWithHandler(const LuaRef& object, F&& errorHandler, Args&&... args
         auto ec = makeErrorCode(ErrorCode::LuaFunctionCallFailed);
 
 #if LUABRIDGE_HAS_EXCEPTIONS
-        if constexpr (! isValidHandler)
-        {
-            if (LuaException::areExceptionsEnabled(L))
-                LuaException::raise(L, ec);
-        }
+        if (LuaException::areExceptionsEnabled(L))
+            LuaException::raise(L, ec);
 #endif
 
         return LuaResult::errorFromStack(L, ec);

--- a/Source/LuaBridge/detail/Invoke.h
+++ b/Source/LuaBridge/detail/Invoke.h
@@ -181,8 +181,8 @@ LuaResult callWithHandler(const LuaRef& object, F&& errorHandler, Args&&... args
 
     if constexpr (isValidHandler)
     {
-       if (errorHandler)
-          detail::push_function(L, std::forward<F>(errorHandler), ""); // Stack: error handler (eh)
+        if (errorHandler)
+            detail::push_function(L, std::forward<F>(errorHandler), ""); // Stack: error handler (eh)
     }
 
     object.push(); // Stack: eh, ref
@@ -196,7 +196,11 @@ LuaResult callWithHandler(const LuaRef& object, F&& errorHandler, Args&&... args
         }
     }
 
-    const int code = lua_pcall(L, sizeof...(Args), LUA_MULTRET, isValidHandler ? (-static_cast<int>(sizeof...(Args)) - 2) : 0);
+    int errorFunction = 0;
+    if constexpr (isValidHandler)
+        errorFunction = errorHandler ? (-static_cast<int>(sizeof...(Args)) - 2) : 0;
+
+    const int code = lua_pcall(L, sizeof...(Args), LUA_MULTRET, errorFunction);
     if (code != LUABRIDGE_LUA_OK)
     {
         auto ec = makeErrorCode(ErrorCode::LuaFunctionCallFailed);

--- a/Source/LuaBridge/detail/Invoke.h
+++ b/Source/LuaBridge/detail/Invoke.h
@@ -199,14 +199,7 @@ LuaResult callWithHandler(const LuaRef& object, F&& errorHandler, Args&&... args
         }
     }
 
-    int errorFunction = 0;
-    if constexpr (isValidHandler)
-    {
-       if (isNonNullHandler)
-          errorFunction = (-static_cast<int>(sizeof...(Args)) - 2);
-    }
-
-    const int code = lua_pcall(L, sizeof...(Args), LUA_MULTRET, errorFunction);
+    const int code = lua_pcall(L, sizeof...(Args), LUA_MULTRET, isNonNullHandler ? (-static_cast<int>(sizeof...(Args)) - 2) : 0);
     if (code != LUABRIDGE_LUA_OK)
     {
         auto ec = makeErrorCode(ErrorCode::LuaFunctionCallFailed);


### PR DESCRIPTION
This is a draft PR for discussion purposes. I am trying to address 2 additional issues that I raised in (now closed) #120.

- **Null error handler**. It would be nice if the code could skip the error handler if it is `nullptr`. ~~I propose a modification in this PR, but for some reason it doesn't work. When there is an an error, the error code returned by `lua_pcall` is 5 ("error in error handling") instead of the actual error. I cannot find any difference in the code path from `call` vs. calling `callWithHandler` with a null handler. But Lua is obviously seeing one. I'd appreciate your ideas on why this might be.~~
- **Always raise LuaException**. There are two types of error handlers: those that monitor and propagate and those that fix/address. It seems to me that it should be quite easy for `lua_pcall` to know which is which, because if the error is handled, it shouldn't return an error status. If the error is not handled, then the `if` block should happen. So there is no need for the conditional. It should always raise the error in the if block. This modification is working for me.

Also, a final question. When the error handler is not null, this code is working as I would like it to. My question is if there is a need to clean up the stack that has the error handler pushed on it.