### PR TITLE
added test to show call-with-handler-failure.

### DIFF
--- a/Tests/Source/LuaRefTests.cpp
+++ b/Tests/Source/LuaRefTests.cpp
@@ -621,6 +621,33 @@ TEST_F(LuaRefTests, CallableWithNullCFunction)
 #endif
 }
 
+TEST_F(LuaRefTests, CallableWithIntToBoolValuedFunction)
+{
+    runLua("function f(x) return x <= 1 end");
+    auto f = luabridge::getGlobal(L, "f");
+    EXPECT_TRUE(f.isCallable());
+    
+    bool calledHandler = false;
+    std::string errorMessage;
+    auto handler = [&](lua_State*) -> int
+    {
+        calledHandler = true;
+
+        if (auto msg = lua_tostring(L, 1))
+            errorMessage = msg;
+
+        return 0;
+    };
+
+    auto result = f.callWithHandler(handler, 2);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(calledHandler);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(result[0].isValid());
+    EXPECT_TRUE(result[0].isBool());
+    EXPECT_TRUE(result[0]);
+}
+
 TEST_F(LuaRefTests, Pop)
 {
     lua_pushstring(L, "hello");


### PR DESCRIPTION
This PR adds a test that illustrates a bug in the `callWithHandler` function. For some reason when this boolean valued Lua function is called, it returns 2 values instead of one, and the first value is not an integer.

If you change the handler to `std::ignore`, the problem does not occur.

Also, as an aside, the `CallableWithNullifiedStdFunction` test aborts the test program when running NoExcept.
