### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/amalgamate.yml
+++ b/.github/workflows/amalgamate.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -221,7 +221,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -124,7 +124,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -158,7 +158,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -188,7 +188,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -213,7 +213,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -57,7 +57,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -127,7 +127,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -162,7 +162,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -192,7 +192,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -218,7 +218,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get -y install ninja-build
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -58,4 +58,4 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -63,7 +63,7 @@ jobs:
           -o "coverage/lua51.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-lua51-${{runner.os}}-${{github.sha}}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -113,7 +113,7 @@ jobs:
           -o "coverage/lua52.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-lua52-${{runner.os}}-${{github.sha}}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -163,7 +163,7 @@ jobs:
           -o "coverage/lua53.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-lua53-${{runner.os}}-${{github.sha}}
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -213,7 +213,7 @@ jobs:
           -o "coverage/lua54.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-lua54-${{runner.os}}-${{github.sha}}
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -259,7 +259,7 @@ jobs:
           -o "coverage/luajit.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-luajit-${{runner.os}}-${{github.sha}}
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -300,7 +300,7 @@ jobs:
           -o "coverage/luau.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-luau-${{runner.os}}-${{github.sha}}
@@ -309,7 +309,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -341,7 +341,7 @@ jobs:
           -o "coverage/ravi.info"
 
     - name: Cache Lcov Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{runner.workspace}}/build/coverage/*.info"
         key: lcov-ravi-${{runner.os}}-${{github.sha}}
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lua51, lua52, lua53, lua54, luajit, luau, ravi]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -363,43 +363,43 @@ jobs:
           cmake -E make_directory ${{runner.workspace}}/build/coverage
 
       - name: Restore Lcov Files Lua 5.1
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-lua51-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files Lua 5.2
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-lua52-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files Lua 5.3
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-lua53-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files Lua 5.4
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-lua54-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files LuaJIT
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-luajit-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files Luau
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-luau-${{runner.os}}-${{github.sha}}
 
       - name: Restore Lcov Files Ravi
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{runner.workspace}}/build/coverage/*.info"
           key: lcov-ravi-${{runner.os}}-${{github.sha}}

--- a/.github/workflows/sonar.yml_
+++ b/.github/workflows/sonar.yml_
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -34,7 +34,7 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build


### PR DESCRIPTION
Fix warnings:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, github/codeql-action/init@v2, github/codeql-action/analyze@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/