### PR TITLE
Bump cmake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 project (LuaBridge)
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 set (LUABRIDGE_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/LuaBridge/Array.h

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 # ====================================================== Locations
 

--- a/Tests/Lua/LuaJIT.2.1/CMakeLists.txt
+++ b/Tests/Lua/LuaJIT.2.1/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Upgrade to luajit-2.1 by 9chu
 # Modified 2022 by kunitoki
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 
 project(Lua C ASM)
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -2,7 +2,7 @@
 
 ## Linux and MacOS
 
-Have CMake 3.5+ and a compiler supporting C++17 installed.
+Have CMake 3.10+ and a compiler supporting C++17 installed.
 
 Run cmake to generate Makefiles:
 
@@ -33,7 +33,7 @@ Run tests from the `build` directory:
 
 ## macOS
 
-Have CMake 3.5+ and Xcode 11+ installed.
+Have CMake 3.10+ and Xcode 11+ installed.
 
 Run cmake to generate Makefiles:
 
@@ -64,7 +64,7 @@ Run tests from the `build` directory:
 
 # Windows
 
-Have CMake 3.5+ and MSVC 2019 installed.
+Have CMake 3.10+ and MSVC 2019 installed.
 
 Run cmake to generate MSVC solution and project files (run `cmake -G` to see all variants):
 


### PR DESCRIPTION
Fix the following warning when using CMake 4.0:
```
CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```