### PR TITLE
Fix luaref returned from call<>()

### DIFF
--- a/Source/LuaBridge/detail/Invoke.h
+++ b/Source/LuaBridge/detail/Invoke.h
@@ -34,22 +34,20 @@ bool is_handler_valid(const F& f) noexcept
 template <class Tuple, std::size_t... Indices>
 TypeResult<Tuple> decode_tuple_result(lua_State* L, int first_result_index, std::index_sequence<Indices...>)
 {
-    Tuple value;
+    auto results = std::make_tuple(
+        Stack<std::tuple_element_t<Indices, Tuple>>::get(L, first_result_index + static_cast<int>(Indices))...);
+
     std::error_code ec;
 
     const bool ok =
         (([&]()
         {
-            using ElementType = std::tuple_element_t<Indices, Tuple>;
-
-            auto element = Stack<ElementType>::get(L, first_result_index + static_cast<int>(Indices));
+            const auto& element = std::get<Indices>(results);
             if (! element)
             {
                 ec = element.error();
                 return false;
             }
-
-            std::get<Indices>(value) = std::move(*element);
             return true;
         }())
             && ...);
@@ -57,7 +55,7 @@ TypeResult<Tuple> decode_tuple_result(lua_State* L, int first_result_index, std:
     if (! ok)
         return ec;
 
-    return value;
+    return Tuple{ std::move(*std::get<Indices>(results))... };
 }
 
 template <class R>

--- a/Tests/Source/LuaRefTests.cpp
+++ b/Tests/Source/LuaRefTests.cpp
@@ -1187,6 +1187,17 @@ TEST_F(LuaRefTests, CallReturningTupleSuccess)
     EXPECT_EQ("hello", std::get<1>(*r));
 }
 
+TEST_F(LuaRefTests, CallReturningTupleWithLuaRef)
+{
+    runLua("result = function() return 1, {2, 'three'} end");
+    auto r = result().call<std::tuple<int, luabridge::LuaRef>>();
+    ASSERT_TRUE(r);
+    EXPECT_EQ(1, std::get<0>(*r));
+    ASSERT_TRUE(std::get<1>(*r).isTable());
+    EXPECT_EQ(2, *std::get<1>(*r)[1].cast<int>());
+    EXPECT_EQ("three", *std::get<1>(*r)[2].cast<std::string>());
+}
+
 TEST_F(LuaRefTests, CallReturningTupleWrongType)
 {
     // Exercises the error path of decodeTupleResult (Invoke.h:58-59):


### PR DESCRIPTION
This pull request improves the handling of Lua function return values as C++ tuples and adds a new test case to verify support for tuples containing `LuaRef` objects. The main change refactors how tuple results are decoded from the Lua stack to be more robust and efficient.

**Tuple result decoding improvements:**
- Refactored `decode_tuple_result` in `Invoke.h` to first collect all stack elements into a tuple of `std::optional` values, then check for errors and construct the result tuple in a single step. This streamlines error handling and avoids partially constructed tuples.

**Testing enhancements:**
- Added a new test `CallReturningTupleWithLuaRef` in `LuaRefTests.cpp` to verify that Lua functions returning a tuple with a table (as a `LuaRef`) are correctly handled, including checking table contents.