### PR TITLE
Add support for addPropertyReadWrite

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -424,6 +424,20 @@ Method registration works just like function registration. Virtual methods work 
 
 As with regular variables and properties, class properties can be marked read-only by passing false in the second parameter, or omitting the set function. The `deriveClass` takes a derived class and one or more registered base classes as template arguments. Inherited methods do not have to be re-declared and will function normally in Lua. If a class has a base class that is **not** registered with Lua, there is no need to declare it as a subclass.
 
+When registering a data member pointer as both readable and writable, the common pattern of passing the same pointer twice to `addProperty` or `addStaticProperty` can be replaced with the convenience methods `addPropertyReadWrite` and `addStaticPropertyReadWrite`:
+
+```cpp
+luabridge::getGlobalNamespace (L)
+  .beginNamespace ("test")
+    .beginClass<A> ("A")
+      .addStaticPropertyReadWrite ("staticData", &A::staticData)  // equivalent to addStaticProperty ("staticData", &A::staticData, &A::staticData)
+      .addPropertyReadWrite ("data", &A::dataMember)              // equivalent to addProperty ("data", &A::dataMember, &A::dataMember)
+    .endClass ()
+  .endNamespace ();
+```
+
+These accept only a pointer-to-data-member (for `addPropertyReadWrite`) or a pointer to a static data member (for `addStaticPropertyReadWrite`). They do not accept getter/setter function pairs; use `addProperty` or `addStaticProperty` directly for those cases.
+
 Remember that in Lua, the colon operator '`:`' is used for method call syntax:
 
 ```lua

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -727,6 +727,12 @@ class Namespace : public detail::Registrar
             return *this;
         }
 
+        template <class Field>
+        Class<T>& addStaticPropertyReadWrite(const char* name, Field member)
+        {
+            return addStaticProperty(name, member, member);
+        }
+
         //=========================================================================================
         /**
          * @brief Add or replace a single static function or multiple overloaded functions.
@@ -908,6 +914,12 @@ class Namespace : public detail::Registrar
             detail::add_property_setter(L, name, -3); // Stack: co, cl, st
 
             return *this;
+        }
+
+        template <class Field>
+        Class<T>& addPropertyReadWrite(const char* name, Field T::*member)
+        {
+            return addProperty(name, member, member);
         }
 
         //=========================================================================================

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -3462,21 +3462,41 @@ struct CoverageBase
 {
     int value = 42;
     int getValue() const { return value; }
+    
+    static int x;
 };
+
+int CoverageBase::x = 100;
 
 struct CoverageDerived : CoverageBase
 {
 };
 } // namespace
 
+TEST_F(ClassTests, DerivedClassAccessesParentStaticProperty)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<CoverageBase>("CoverageBase")
+            .addStaticProperty("value", &CoverageBase::x)
+            .addStaticPropertyReadWrite("value_rw", &CoverageBase::x)
+        .endClass()
+        .deriveClass<CoverageDerived, CoverageBase>("CoverageDerived")
+            .addConstructor<void (*)()>()
+        .endClass();
+
+    EXPECT_TRUE(runLua("result = CoverageDerived.value"));
+    EXPECT_EQ(100, result<int>());
+
+    EXPECT_TRUE(runLua("CoverageDerived.value_rw = 13; result = CoverageDerived.value_rw"));
+    EXPECT_EQ(13, result<int>());
+}
+
 TEST_F(ClassTests, DerivedClassAccessesParentProperty)
 {
-    // Covers CFunctions.h:476-477, 511 - parent propget table lookup in index_metamethod
-    // Derived is registered without any properties; accessing "value" traverses parent list
-    // and finds it in Base's propget table (lines 491-504) or continues iteration (476-477, 511)
     luabridge::getGlobalNamespace(L)
         .beginClass<CoverageBase>("CoverageBase")
             .addProperty("value", &CoverageBase::value)
+            .addPropertyReadWrite("value_rw", &CoverageBase::value)
         .endClass()
         .deriveClass<CoverageDerived, CoverageBase>("CoverageDerived")
             .addConstructor<void (*)()>()
@@ -3484,13 +3504,13 @@ TEST_F(ClassTests, DerivedClassAccessesParentProperty)
 
     EXPECT_TRUE(runLua("result = CoverageDerived().value"));
     EXPECT_EQ(42, result<int>());
+
+    EXPECT_TRUE(runLua("obj = CoverageDerived(); obj.value_rw = 13; result = obj.value"));
+    EXPECT_EQ(13, result<int>());
 }
 
 TEST_F(ClassTests, DerivedClassAccessesMetamethodNameReturnsNil)
 {
-    // Covers CFunctions.h:381-382 - metamethod name protection in index_metamethod
-    // Derived class uses complex index_metamethod (not simple); accessing "__index"
-    // triggers the is_metamethod guard and returns nil
     luabridge::getGlobalNamespace(L)
         .beginClass<CoverageBase>("CoverageBase")
         .endClass()
@@ -3504,8 +3524,6 @@ TEST_F(ClassTests, DerivedClassAccessesMetamethodNameReturnsNil)
 
 TEST_F(ClassTests, StaticClassAccessReturnsMethodFromConstTable)
 {
-    // Covers CFunctions.h:613 - in index_metamethod_simple<false> (static path),
-    // upvalue[2] (const/methods table) lookup returns a non-nil value
     struct SimpleClass
     {
         int getValue() const { return 7; }


### PR DESCRIPTION
This pull request introduces two new convenience methods for registering read-write properties in LuaBridge, updates the documentation to describe their usage, and adds comprehensive tests to ensure correct behavior and inheritance support.

**API Enhancements:**

* Added `addPropertyReadWrite` to `Class<T>` for registering a data member as both readable and writable in one call, instead of passing the same pointer twice to `addProperty`.
* Added `addStaticPropertyReadWrite` to `Class<T>` for registering a static data member as both readable and writable in one call, instead of passing the same pointer twice to `addStaticProperty`.

**Documentation Updates:**

* Updated `Manual.md` to document the new `addPropertyReadWrite` and `addStaticPropertyReadWrite` methods, including usage examples and guidance on when to use these versus the existing property registration methods.

**Testing Improvements:**

* Added and extended tests in `ClassTests.cpp` to verify that derived classes correctly inherit and access parent class properties registered with the new methods, including both static and instance properties.
* Cleaned up test comments for clarity and conciseness.