### PR TITLE
Support for bind_front

### DIFF
--- a/Distribution/LuaBridge/LuaBridge.h
+++ b/Distribution/LuaBridge/LuaBridge.h
@@ -34,6 +34,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 
@@ -299,8 +300,32 @@ struct function_traits_impl<R (__fastcall C::*)(Args...) const noexcept, true> :
 };
 #endif
 
+template <class F, class = void>
+struct has_call_operator : std::false_type
+{
+};
+
 template <class F>
-struct functor_traits_impl : function_traits_impl<decltype(&F::operator()), true>
+struct has_call_operator<F, std::void_t<decltype(&F::operator())>> : std::true_type
+{
+};
+
+template <class F>
+inline static constexpr bool has_call_operator_v = has_call_operator<F>::value;
+
+template <class F, class = void>
+struct functor_traits_impl
+{
+};
+
+template <class F>
+struct functor_traits_impl<F, std::enable_if_t<has_call_operator_v<F>>> : function_traits_impl<decltype(&F::operator()), true>
+{
+};
+
+template <class F>
+struct functor_traits_impl<F, std::enable_if_t<!has_call_operator_v<F> && std::is_invocable_v<F&>>>
+    : function_traits_base<false, false, std::invoke_result_t<F&>>
 {
 };
 
@@ -310,6 +335,19 @@ struct function_traits : std::conditional_t<std::is_class_v<F>,
                                             detail::function_traits_impl<F, true>>
 {
 };
+
+template <class T, bool IsClass = std::is_class_v<T>, class = void>
+struct has_function_traits : std::false_type
+{
+};
+
+template <class T>
+struct has_function_traits<T, true, std::void_t<typename function_traits<T>::result_type, typename function_traits<T>::argument_types>> : std::true_type
+{
+};
+
+template <class T>
+inline static constexpr bool has_function_traits_v = has_function_traits<T>::value;
 
 template <std::size_t I, class F, class = void>
 struct function_argument_or_void
@@ -352,6 +390,12 @@ struct is_callable
 
 template <class T>
 struct is_callable<T, std::void_t<decltype(&T::operator())>>
+{
+    static constexpr bool value = true;
+};
+
+template <class T>
+struct is_callable<T, std::enable_if_t<std::is_class_v<T> && !has_call_operator_v<T> && has_function_traits_v<T>>>
 {
     static constexpr bool value = true;
 };
@@ -539,7 +583,172 @@ struct remove_first_type<std::tuple<T, Ts...>>
 template <class T>
 using remove_first_type_t = typename remove_first_type<T>::type;
 
+template <std::size_t N, class Tuple>
+struct tuple_drop_first
+{
+    using type = typename tuple_drop_first<N - 1, remove_first_type_t<Tuple>>::type;
+};
+
+template <class Tuple>
+struct tuple_drop_first<0, Tuple>
+{
+    using type = Tuple;
+};
+
+template <std::size_t N, class Tuple>
+using tuple_drop_first_t = typename tuple_drop_first<N, Tuple>::type;
+
+template <class T, class Tuple>
+struct tuple_prepend;
+
+template <class T, class... Ts>
+struct tuple_prepend<T, std::tuple<Ts...>>
+{
+    using type = std::tuple<T, Ts...>;
+};
+
+template <class T, class Tuple>
+using tuple_prepend_t = typename tuple_prepend<T, Tuple>::type;
+
+template <std::size_t N, class Tuple, class Accum = std::tuple<>>
+struct tuple_take_first_impl
+{
+    using type = Accum;
+};
+
+template <std::size_t N, class T, class... Ts, class... Acc>
+struct tuple_take_first_impl<N, std::tuple<T, Ts...>, std::tuple<Acc...>>
+{
+    using type = typename tuple_take_first_impl<N - 1, std::tuple<Ts...>, std::tuple<Acc..., T>>::type;
+};
+
+template <class T, class... Ts, class... Acc>
+struct tuple_take_first_impl<0, std::tuple<T, Ts...>, std::tuple<Acc...>>
+{
+    using type = std::tuple<Acc...>;
+};
+
+template <std::size_t N, class Tuple>
+using tuple_take_first_t = typename tuple_take_first_impl<N, Tuple>::type;
+
+template <class F>
+struct member_function_class;
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...)> { using type = C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) const> { using type = const C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) noexcept> { using type = C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) const noexcept> { using type = const C; };
+
+template <class F>
+using member_function_class_t = typename member_function_class<F>::type;
+
+template <class Fn, class ExplicitRemaining, bool IsMember>
+struct bind_back_leading_impl
+{
+    using type = ExplicitRemaining;
+};
+
+template <class Fn, class ExplicitRemaining>
+struct bind_back_leading_impl<Fn, ExplicitRemaining, true>
+{
+    using type = tuple_prepend_t<member_function_class_t<Fn>*, ExplicitRemaining>;
+};
+
+template <class Fn, class ExplicitRemaining>
+using bind_back_leading_t =
+    typename bind_back_leading_impl<Fn, ExplicitRemaining, std::is_member_function_pointer_v<Fn>>::type;
+
+template <class R, class RemainingArgsTuple, class Fn, class... BoundArgs>
+struct bind_front_wrapper;
+
+template <class R, class... Remaining, class Fn, class... BoundArgs>
+struct bind_front_wrapper<R, std::tuple<Remaining...>, Fn, BoundArgs...>
+{
+    Fn fn_;
+    std::tuple<BoundArgs...> bound_;
+
+    template <class F, class... BA>
+    bind_front_wrapper(F&& f, BA&&... ba)
+        : fn_(std::forward<F>(f)), bound_(std::forward<BA>(ba)...)
+    {
+    }
+
+    R operator()(Remaining... args) const
+    {
+        return std::apply([&](const auto&... ba) { return std::invoke(fn_, ba..., args...); }, bound_);
+    }
+};
+
 } 
+
+template <class F, class... BoundArgs>
+auto bind_front(F&& f, BoundArgs&&... args)
+{
+    using Fn = std::decay_t<F>;
+    using FnTraits = detail::function_traits<Fn>;
+
+    static constexpr std::size_t skip = std::is_member_function_pointer_v<Fn> ? 1u : 0u;
+    static constexpr std::size_t num_effective_bound = sizeof...(BoundArgs) - skip;
+
+    using remaining = detail::tuple_drop_first_t<num_effective_bound, typename FnTraits::argument_types>;
+    using R = typename FnTraits::result_type;
+
+    return detail::bind_front_wrapper<R, remaining, Fn, std::decay_t<BoundArgs>...>(
+        std::forward<F>(f), std::forward<BoundArgs>(args)...);
+}
+
+namespace detail {
+
+template <class R, class LeadingArgsTuple, class Fn, class... BoundArgs>
+struct bind_back_wrapper;
+
+template <class R, class... Leading, class Fn, class... BoundArgs>
+struct bind_back_wrapper<R, std::tuple<Leading...>, Fn, BoundArgs...>
+{
+    Fn fn_;
+    std::tuple<BoundArgs...> bound_;
+
+    template <class F, class... BA>
+    bind_back_wrapper(F&& f, BA&&... ba)
+        : fn_(std::forward<F>(f)), bound_(std::forward<BA>(ba)...)
+    {
+    }
+
+    R operator()(Leading... args) const
+    {
+        return std::apply([&](const auto&... ba) { return std::invoke(fn_, args..., ba...); }, bound_);
+    }
+};
+
+} 
+
+template <class F, class... BoundArgs>
+auto bind_back(F&& f, BoundArgs&&... args)
+{
+    using Fn = std::decay_t<F>;
+    using FnTraits = detail::function_traits<Fn>;
+
+    static constexpr std::size_t num_explicit = FnTraits::arity;
+    static constexpr std::size_t num_bound = sizeof...(BoundArgs);
+    static constexpr std::size_t num_remaining = num_explicit - num_bound;
+
+    using explicit_remaining = detail::tuple_take_first_t<num_remaining, typename FnTraits::argument_types>;
+
+    using leading = detail::bind_back_leading_t<Fn, explicit_remaining>;
+
+    using R = typename FnTraits::result_type;
+
+    return detail::bind_back_wrapper<R, leading, Fn, std::decay_t<BoundArgs>...>(
+        std::forward<F>(f), std::forward<BoundArgs>(args)...);
+}
+
 } 
 
 
@@ -6066,10 +6275,10 @@ inline void dumpState(lua_State* L, unsigned maxDepth = 1, std::ostream& stream 
 
 namespace luabridge {
 
-template <class T>
-struct Stack<std::list<T>>
+template <class T, class Allocator>
+struct Stack<std::list<T, Allocator>>
 {
-    using Type = std::list<T>;
+    using Type = std::list<T, Allocator>;
     
     [[nodiscard]] static Result push(lua_State* L, const Type& list)
     {
@@ -12663,10 +12872,10 @@ ScopeGuard(F&&) -> ScopeGuard<F>;
 
 namespace luabridge {
 
-template <class K, class V>
-struct Stack<std::map<K, V>>
+template <class K, class V, class Compare, class Allocator>
+struct Stack<std::map<K, V, Compare, Allocator>>
 {
-    using Type = std::map<K, V>;
+    using Type = std::map<K, V, Compare, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& map)
     {
@@ -12740,10 +12949,10 @@ struct Stack<std::map<K, V>>
 
 namespace luabridge {
 
-template <class K>
-struct Stack<std::set<K>>
+template <class K, class Compare, class Allocator>
+struct Stack<std::set<K, Compare, Allocator>>
 {
-    using Type = std::set<K>;
+    using Type = std::set<K, Compare, Allocator>;
     
     [[nodiscard]] static Result push(lua_State* L, const Type& set)
     {
@@ -12812,10 +13021,10 @@ struct Stack<std::set<K>>
 
 namespace luabridge {
 
-template <class K, class V>
-struct Stack<std::unordered_map<K, V>>
+template <class K, class V, class Hash, class KeyEqual, class Allocator>
+struct Stack<std::unordered_map<K, V, Hash, KeyEqual, Allocator>>
 {
-    using Type = std::unordered_map<K, V>;
+    using Type = std::unordered_map<K, V, Hash, KeyEqual, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& map)
     {
@@ -12885,14 +13094,87 @@ struct Stack<std::unordered_map<K, V>>
 
 // End File: Source/LuaBridge/UnorderedMap.h
 
+// Begin File: Source/LuaBridge/Variant.h
+
+namespace luabridge {
+
+template <class... Args>
+struct Stack<std::variant<Args...>>
+{
+    using Type = std::variant<Args...>;
+
+    [[nodiscard]] static Result push(lua_State* L, const Type& variant)
+    {
+        return std::visit([L](const auto& value) { return Stack<std::decay_t<decltype(value)>>::push(L, value); }, variant);
+    }
+
+    [[nodiscard]] static TypeResult<Type> get(lua_State* L, int index)
+    {
+        return tryGet<Args...>(L, index);
+    }
+
+    [[nodiscard]] static bool isInstance(lua_State* L, int index)
+    {
+        return (Stack<Args>::isInstance(L, index) || ...);
+    }
+
+private:
+    template <class T, class... Rest>
+    [[nodiscard]] static TypeResult<Type> tryGet(lua_State* L, int index)
+    {
+        if (auto value = Stack<T>::get(L, index))
+            return Type{ std::in_place_type<T>, std::move(*value) };
+
+        if constexpr (sizeof...(Rest) > 0)
+            return tryGet<Rest...>(L, index);
+
+        return makeErrorCode(ErrorCode::InvalidTypeCast);
+    }
+};
+
+template <>
+struct Stack<std::monostate>
+{
+    using Type = std::monostate;
+
+    [[nodiscard]] static Result push(lua_State* L, const Type&)
+    {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+        if (! lua_checkstack(L, 1))
+            return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+        lua_pushnil(L);
+        return {};
+    }
+
+    [[nodiscard]] static TypeResult<Type> get(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+            return Type{};
+
+        return makeErrorCode(ErrorCode::InvalidTypeCast);
+    }
+
+    [[nodiscard]] static bool isInstance(lua_State* L, int index)
+    {
+        return lua_isnoneornil(L, index);
+    }
+};
+
+} 
+
+
+// End File: Source/LuaBridge/Variant.h
+
 // Begin File: Source/LuaBridge/Vector.h
 
 namespace luabridge {
 
-template <class T>
-struct Stack<std::vector<T>>
+template <class T, class Allocator>
+struct Stack<std::vector<T, Allocator>>
 {
-    using Type = std::vector<T>;
+    using Type = std::vector<T, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& vector)
     {

--- a/Manual.md
+++ b/Manual.md
@@ -33,7 +33,8 @@ Contents
     *   [2.4 - Property Member Proxies](#24---property-member-proxies)
     *   [2.5 - Function Member Proxies](#25---function-member-proxies)
     *   [2.5.1 - Partial Application with luabridge::bind_front](#251---partial-application-with-luabridgebind_front)
-    *   [2.5.2 - Function Overloading](#252---function-overloading)
+    *   [2.5.2 - Partial Application with luabridge::bind_back](#252---partial-application-with-luabridgebind_back)
+    *   [2.5.3 - Function Overloading](#253---function-overloading)
     *   [2.6 - Constructors](#26---constructors)
     *   [2.6.1 - Constructor Proxies](#261---constructor-proxies)
     *   [2.6.2 - Constructor Factories](#262---constructor-factories)
@@ -621,20 +622,59 @@ ns.addFunction ("add10", std::function<int(int)> (std::bind_front (&add, 10)));
 ns.addFunction ("add10", luabridge::bind_front (&add, 10));
 ```
 
-It also works with member function pointers, where the bound object is not counted as a Lua-visible parameter:
+It also works with member function pointers. The bound object is not counted as a Lua-visible parameter, so `bind_front` turns a member function into a plain callable that Lua sees as a regular function:
 
 ```cpp
-struct Vec { float coord [3]; };
-float getCoord (const Vec* v, int i) { return v->coord [i]; }
+struct Vec { float coord [3]; float getCoord (int i) const { return coord [i]; } };
 
-ns.beginClass<Vec> ("Vec")
-  .addFunction ("x", luabridge::bind_front (&getCoord, 0))
-  .addFunction ("y", luabridge::bind_front (&getCoord, 1))
-  .addFunction ("z", luabridge::bind_front (&getCoord, 2))
-.endClass ();
+Vec v;
+// Bind v as the object; Lua supplies the index
+ns.addFunction ("getCoord", luabridge::bind_front (&Vec::getCoord, &v));
+// Lua: getCoord(0) == v.coord[0]
 ```
 
-### 2.5.2 - Function Overloading
+It also accepts lambdas:
+
+```cpp
+int base = 10;
+ns.addFunction ("addBase", luabridge::bind_front ([base](int offset, int v) { return base + offset + v; }, 2));
+// Lua: addBase(30) == 42
+```
+
+### 2.5.2 - Partial Application with luabridge::bind_back
+
+`luabridge::bind_back` is the trailing-argument counterpart to `bind_front`: it pre-binds the **last** arguments of a callable, leaving the **leading** arguments for Lua to supply.
+
+```cpp
+int add (int a, int b) { return a + b; }
+
+// bind_back fixes the trailing argument; Lua supplies the leading one
+ns.addFunction ("add10", luabridge::bind_back (&add, 10));
+// Lua: add10(32) == 42
+```
+
+For member function pointers, `bind_back` automatically prepends the class pointer to the remaining (Lua-visible) parameter list so that LuaBridge can dispatch it as a proxy function. This lets you pre-bind a method's trailing arguments while the object still comes from Lua:
+
+```cpp
+struct Vec { float coord [3]; float getCoord (int i) const { return coord [i]; } };
+
+ns.beginClass<Vec> ("Vec")
+  .addFunction ("x", luabridge::bind_back (&Vec::getCoord, 0))
+  .addFunction ("y", luabridge::bind_back (&Vec::getCoord, 1))
+  .addFunction ("z", luabridge::bind_back (&Vec::getCoord, 2))
+.endClass ();
+// Lua: v:x() returns v.coord[0], v:y() returns v.coord[1], etc.
+```
+
+`bind_back` also accepts lambdas:
+
+```cpp
+int base = 10;
+ns.addFunction ("addBase", luabridge::bind_back ([base](int v, int offset) { return base + offset + v; }, 2));
+// Lua: addBase(30) == 42
+```
+
+### 2.5.3 - Function Overloading
 
 When specifying more than one method to the `addFunction` or `addStaticFunction` of both `Namespace` and `Class`, those overloads will be invoked in case of a call. Only overloads that have matched arguments arity will be considered, and they will be tried from first to last until the call succeeds.
 

--- a/Manual.md
+++ b/Manual.md
@@ -32,7 +32,8 @@ Contents
         *   [2.3.1 - Multiple Inheritance](#231---multiple-inheritance)
     *   [2.4 - Property Member Proxies](#24---property-member-proxies)
     *   [2.5 - Function Member Proxies](#25---function-member-proxies)
-    *   [2.5.1 - Function Overloading](#251---function-overloading)
+    *   [2.5.1 - Partial Application with luabridge::bind_front](#251---partial-application-with-luabridgebind_front)
+    *   [2.5.2 - Function Overloading](#252---function-overloading)
     *   [2.6 - Constructors](#26---constructors)
     *   [2.6.1 - Constructor Proxies](#261---constructor-proxies)
     *   [2.6.2 - Constructor Factories](#262---constructor-factories)
@@ -602,7 +603,38 @@ luabridge::getGlobalNamespace (L)
 
 Of course when not capturing, it is better to prefix the lambda with `+` so it is converted and stored internally to a function pointer instead of an `std::function`, so it is actually lighter to store and faster to call.
 
-### 2.5.1 - Function Overloading
+### 2.5.1 - Partial Application with luabridge::bind_front
+
+`std::bind_front` (C++20) returns a callable whose `operator()` is a template, so LuaBridge cannot statically resolve its argument types. Passing such a result directly to `addFunction` therefore fails to compile. The workaround without `luabridge::bind_front` is an explicit cast to `std::function`:
+
+```cpp
+int add (int a, int b) { return a + b; }
+
+// Verbose: explicit signature required
+ns.addFunction ("add10", std::function<int(int)> (std::bind_front (&add, 10)));
+```
+
+`luabridge::bind_front` is a drop-in replacement that deduces the remaining argument types from the underlying callable's signature, so no explicit cast is needed:
+
+```cpp
+// Concise: types are deduced automatically
+ns.addFunction ("add10", luabridge::bind_front (&add, 10));
+```
+
+It also works with member function pointers, where the bound object is not counted as a Lua-visible parameter:
+
+```cpp
+struct Vec { float coord [3]; };
+float getCoord (const Vec* v, int i) { return v->coord [i]; }
+
+ns.beginClass<Vec> ("Vec")
+  .addFunction ("x", luabridge::bind_front (&getCoord, 0))
+  .addFunction ("y", luabridge::bind_front (&getCoord, 1))
+  .addFunction ("z", luabridge::bind_front (&getCoord, 2))
+.endClass ();
+```
+
+### 2.5.2 - Function Overloading
 
 When specifying more than one method to the `addFunction` or `addStaticFunction` of both `Namespace` and `Class`, those overloads will be invoked in case of a call. Only overloads that have matched arguments arity will be considered, and they will be tried from first to last until the call succeeds.
 

--- a/Source/LuaBridge/List.h
+++ b/Source/LuaBridge/List.h
@@ -15,10 +15,10 @@ namespace luabridge {
 /**
  * @brief Stack specialization for `std::array`.
  */
-template <class T>
-struct Stack<std::list<T>>
+template <class T, class Allocator>
+struct Stack<std::list<T, Allocator>>
 {
-    using Type = std::list<T>;
+    using Type = std::list<T, Allocator>;
     
     [[nodiscard]] static Result push(lua_State* L, const Type& list)
     {

--- a/Source/LuaBridge/Map.h
+++ b/Source/LuaBridge/Map.h
@@ -15,10 +15,10 @@ namespace luabridge {
 /**
  * @brief Stack specialization for `std::map`.
  */
-template <class K, class V>
-struct Stack<std::map<K, V>>
+template <class K, class V, class Compare, class Allocator>
+struct Stack<std::map<K, V, Compare, Allocator>>
 {
-    using Type = std::map<K, V>;
+    using Type = std::map<K, V, Compare, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& map)
     {

--- a/Source/LuaBridge/Set.h
+++ b/Source/LuaBridge/Set.h
@@ -14,10 +14,10 @@ namespace luabridge {
 /**
  * @brief Stack specialization for `std::set`.
  */
-template <class K>
-struct Stack<std::set<K>>
+template <class K, class Compare, class Allocator>
+struct Stack<std::set<K, Compare, Allocator>>
 {
-    using Type = std::set<K>;
+    using Type = std::set<K, Compare, Allocator>;
     
     [[nodiscard]] static Result push(lua_State* L, const Type& set)
     {

--- a/Source/LuaBridge/UnorderedMap.h
+++ b/Source/LuaBridge/UnorderedMap.h
@@ -15,10 +15,10 @@ namespace luabridge {
 /**
  * @brief Stack specialization for `std::unordered_map`.
  */
-template <class K, class V>
-struct Stack<std::unordered_map<K, V>>
+template <class K, class V, class Hash, class KeyEqual, class Allocator>
+struct Stack<std::unordered_map<K, V, Hash, KeyEqual, Allocator>>
 {
-    using Type = std::unordered_map<K, V>;
+    using Type = std::unordered_map<K, V, Hash, KeyEqual, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& map)
     {

--- a/Source/LuaBridge/Variant.h
+++ b/Source/LuaBridge/Variant.h
@@ -1,0 +1,85 @@
+// https://github.com/kunitoki/LuaBridge3
+// Copyright 2026, kunitoki
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "detail/Stack.h"
+
+#include <utility>
+#include <variant>
+
+namespace luabridge {
+
+//=================================================================================================
+/**
+ * @brief Stack specialization for `std::variant`.
+ */
+template <class... Args>
+struct Stack<std::variant<Args...>>
+{
+    using Type = std::variant<Args...>;
+
+    [[nodiscard]] static Result push(lua_State* L, const Type& variant)
+    {
+        return std::visit([L](const auto& value) { return Stack<std::decay_t<decltype(value)>>::push(L, value); }, variant);
+    }
+
+    [[nodiscard]] static TypeResult<Type> get(lua_State* L, int index)
+    {
+        return tryGet<Args...>(L, index);
+    }
+
+    [[nodiscard]] static bool isInstance(lua_State* L, int index)
+    {
+        return (Stack<Args>::isInstance(L, index) || ...);
+    }
+
+private:
+    template <class T, class... Rest>
+    [[nodiscard]] static TypeResult<Type> tryGet(lua_State* L, int index)
+    {
+        if (auto value = Stack<T>::get(L, index))
+            return Type{ std::in_place_type<T>, std::move(*value) };
+
+        if constexpr (sizeof...(Rest) > 0)
+            return tryGet<Rest...>(L, index);
+
+        return makeErrorCode(ErrorCode::InvalidTypeCast);
+    }
+};
+
+/**
+ * @brief Stack specialization for `std::monostate`.
+ */
+template <>
+struct Stack<std::monostate>
+{
+    using Type = std::monostate;
+
+    [[nodiscard]] static Result push(lua_State* L, const Type&)
+    {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+        if (! lua_checkstack(L, 1))
+            return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+        lua_pushnil(L);
+        return {};
+    }
+
+    [[nodiscard]] static TypeResult<Type> get(lua_State* L, int index)
+    {
+        if (lua_isnoneornil(L, index))
+            return Type{};
+
+        return makeErrorCode(ErrorCode::InvalidTypeCast);
+    }
+
+    [[nodiscard]] static bool isInstance(lua_State* L, int index)
+    {
+        return lua_isnoneornil(L, index);
+    }
+};
+
+} // namespace luabridge

--- a/Source/LuaBridge/Vector.h
+++ b/Source/LuaBridge/Vector.h
@@ -15,10 +15,10 @@ namespace luabridge {
 /**
  * @brief Stack specialization for `std::vector`.
  */
-template <class T>
-struct Stack<std::vector<T>>
+template <class T, class Allocator>
+struct Stack<std::vector<T, Allocator>>
 {
-    using Type = std::vector<T>;
+    using Type = std::vector<T, Allocator>;
 
     [[nodiscard]] static Result push(lua_State* L, const Type& vector)
     {

--- a/Source/LuaBridge/detail/FuncTraits.h
+++ b/Source/LuaBridge/detail/FuncTraits.h
@@ -195,8 +195,32 @@ struct function_traits_impl<R (__fastcall C::*)(Args...) const noexcept, true> :
 };
 #endif
 
+template <class F, class = void>
+struct has_call_operator : std::false_type
+{
+};
+
 template <class F>
-struct functor_traits_impl : function_traits_impl<decltype(&F::operator()), true>
+struct has_call_operator<F, std::void_t<decltype(&F::operator())>> : std::true_type
+{
+};
+
+template <class F>
+inline static constexpr bool has_call_operator_v = has_call_operator<F>::value;
+
+template <class F, class = void>
+struct functor_traits_impl
+{
+};
+
+template <class F>
+struct functor_traits_impl<F, std::enable_if_t<has_call_operator_v<F>>> : function_traits_impl<decltype(&F::operator()), true>
+{
+};
+
+template <class F>
+struct functor_traits_impl<F, std::enable_if_t<!has_call_operator_v<F> && std::is_invocable_v<F&>>>
+    : function_traits_base<false, false, std::invoke_result_t<F&>>
 {
 };
 
@@ -212,6 +236,19 @@ struct function_traits : std::conditional_t<std::is_class_v<F>,
                                             detail::function_traits_impl<F, true>>
 {
 };
+
+template <class T, bool IsClass = std::is_class_v<T>, class = void>
+struct has_function_traits : std::false_type
+{
+};
+
+template <class T>
+struct has_function_traits<T, true, std::void_t<typename function_traits<T>::result_type, typename function_traits<T>::argument_types>> : std::true_type
+{
+};
+
+template <class T>
+inline static constexpr bool has_function_traits_v = has_function_traits<T>::value;
 
 //=================================================================================================
 /**
@@ -299,6 +336,12 @@ struct is_callable
 
 template <class T>
 struct is_callable<T, std::void_t<decltype(&T::operator())>>
+{
+    static constexpr bool value = true;
+};
+
+template <class T>
+struct is_callable<T, std::enable_if_t<std::is_class_v<T> && !has_call_operator_v<T> && has_function_traits_v<T>>>
 {
     static constexpr bool value = true;
 };
@@ -547,5 +590,96 @@ struct remove_first_type<std::tuple<T, Ts...>>
 template <class T>
 using remove_first_type_t = typename remove_first_type<T>::type;
 
+//=================================================================================================
+/**
+ * @brief Drop the first N types from a tuple.
+ */
+template <std::size_t N, class Tuple>
+struct tuple_drop_first
+{
+    using type = typename tuple_drop_first<N - 1, remove_first_type_t<Tuple>>::type;
+};
+
+template <class Tuple>
+struct tuple_drop_first<0, Tuple>
+{
+    using type = Tuple;
+};
+
+template <std::size_t N, class Tuple>
+using tuple_drop_first_t = typename tuple_drop_first<N, Tuple>::type;
+
+//=================================================================================================
+/**
+ * @brief Internal storage for luabridge::bind_front — exposes a non-template operator() so that
+ *        function_traits can statically resolve result_type and argument_types.
+ */
+template <class R, class RemainingArgsTuple, class Fn, class... BoundArgs>
+struct bind_front_wrapper;
+
+template <class R, class... Remaining, class Fn, class... BoundArgs>
+struct bind_front_wrapper<R, std::tuple<Remaining...>, Fn, BoundArgs...>
+{
+    Fn fn_;
+    std::tuple<BoundArgs...> bound_;
+
+    template <class F, class... BA>
+    bind_front_wrapper(F&& f, BA&&... ba)
+        : fn_(std::forward<F>(f)), bound_(std::forward<BA>(ba)...)
+    {
+    }
+
+    R operator()(Remaining... args) const
+    {
+        return std::apply([&](const auto&... ba) { return std::invoke(fn_, ba..., args...); }, bound_);
+    }
+};
+
 } // namespace detail
+
+//=================================================================================================
+/**
+ * @brief Drop-in replacement for std::bind_front with statically introspectable argument types.
+ *
+ * std::bind_front returns an object whose operator() is a template, so its argument and result
+ * types cannot be resolved at compile time without an explicit std::function<Sig> cast. This
+ * wrapper stores the callable and its leading bound arguments, then exposes a concrete
+ * non-template operator() whose parameter types are derived directly from the underlying
+ * callable's signature. This lets LuaBridge register the result with addFunction / addProperty /
+ * addMethod without any extra annotation.
+ *
+ * @code
+ * // Instead of:
+ * ns.addFunction("add", std::function<int(int)>(std::bind_front(&add2, 10)));
+ *
+ * // Write:
+ * ns.addFunction("add", luabridge::bind_front(&add2, 10));
+ * @endcode
+ *
+ * For member function pointers the implicit object argument consumed by std::invoke is not
+ * counted as part of the remaining (Lua-visible) parameter list, matching std::bind_front
+ * semantics.
+ *
+ * @tparam F     Callable type (function pointer, member function pointer, functor).
+ * @tparam BoundArgs Leading argument types to bind.
+ * @param  f     The callable to wrap.
+ * @param  args  Leading arguments forwarded into the wrapper by value.
+ * @return A callable object whose operator() accepts the remaining (unbound) arguments.
+ */
+template <class F, class... BoundArgs>
+auto bind_front(F&& f, BoundArgs&&... args)
+{
+    using Fn = std::decay_t<F>;
+    using FnTraits = detail::function_traits<Fn>;
+
+    static constexpr std::size_t skip = FnTraits::is_member ? 1u : 0u;
+    static constexpr std::size_t num_effective_bound = sizeof...(BoundArgs) - skip;
+
+    using remaining = detail::tuple_drop_first_t<num_effective_bound, typename FnTraits::argument_types>;
+    using R = typename FnTraits::result_type;
+
+    return detail::bind_front_wrapper<R, remaining, Fn, std::decay_t<BoundArgs>...>(
+        std::forward<F>(f), std::forward<BoundArgs>(args)...);
+}
+
 } // namespace luabridge

--- a/Source/LuaBridge/detail/FuncTraits.h
+++ b/Source/LuaBridge/detail/FuncTraits.h
@@ -611,6 +611,91 @@ using tuple_drop_first_t = typename tuple_drop_first<N, Tuple>::type;
 
 //=================================================================================================
 /**
+ * @brief Prepend a type to a tuple.
+ */
+template <class T, class Tuple>
+struct tuple_prepend;
+
+template <class T, class... Ts>
+struct tuple_prepend<T, std::tuple<Ts...>>
+{
+    using type = std::tuple<T, Ts...>;
+};
+
+template <class T, class Tuple>
+using tuple_prepend_t = typename tuple_prepend<T, Tuple>::type;
+
+//=================================================================================================
+/**
+ * @brief Take only the first N types from a tuple (uses an accumulator to avoid ambiguity).
+ */
+template <std::size_t N, class Tuple, class Accum = std::tuple<>>
+struct tuple_take_first_impl
+{
+    using type = Accum;
+};
+
+template <std::size_t N, class T, class... Ts, class... Acc>
+struct tuple_take_first_impl<N, std::tuple<T, Ts...>, std::tuple<Acc...>>
+{
+    using type = typename tuple_take_first_impl<N - 1, std::tuple<Ts...>, std::tuple<Acc..., T>>::type;
+};
+
+template <class T, class... Ts, class... Acc>
+struct tuple_take_first_impl<0, std::tuple<T, Ts...>, std::tuple<Acc...>>
+{
+    using type = std::tuple<Acc...>;
+};
+
+template <std::size_t N, class Tuple>
+using tuple_take_first_t = typename tuple_take_first_impl<N, Tuple>::type;
+
+//=================================================================================================
+/**
+ * @brief Extracts the class type from a member function pointer.
+ */
+template <class F>
+struct member_function_class;
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...)> { using type = C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) const> { using type = const C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) noexcept> { using type = C; };
+
+template <class C, class R, class... Args>
+struct member_function_class<R (C::*)(Args...) const noexcept> { using type = const C; };
+
+template <class F>
+using member_function_class_t = typename member_function_class<F>::type;
+
+//=================================================================================================
+/**
+ * @brief Computes the leading argument tuple for bind_back: for member function pointers,
+ *        prepends ClassType* to the explicit remaining args; for all other callables, returns
+ *        the explicit remaining args unchanged.
+ */
+template <class Fn, class ExplicitRemaining, bool IsMember>
+struct bind_back_leading_impl
+{
+    using type = ExplicitRemaining;
+};
+
+template <class Fn, class ExplicitRemaining>
+struct bind_back_leading_impl<Fn, ExplicitRemaining, true>
+{
+    using type = tuple_prepend_t<member_function_class_t<Fn>*, ExplicitRemaining>;
+};
+
+template <class Fn, class ExplicitRemaining>
+using bind_back_leading_t =
+    typename bind_back_leading_impl<Fn, ExplicitRemaining, std::is_member_function_pointer_v<Fn>>::type;
+
+//=================================================================================================
+/**
  * @brief Internal storage for luabridge::bind_front — exposes a non-template operator() so that
  *        function_traits can statically resolve result_type and argument_types.
  */
@@ -645,16 +730,7 @@ struct bind_front_wrapper<R, std::tuple<Remaining...>, Fn, BoundArgs...>
  * types cannot be resolved at compile time without an explicit std::function<Sig> cast. This
  * wrapper stores the callable and its leading bound arguments, then exposes a concrete
  * non-template operator() whose parameter types are derived directly from the underlying
- * callable's signature. This lets LuaBridge register the result with addFunction / addProperty /
- * addMethod without any extra annotation.
- *
- * @code
- * // Instead of:
- * ns.addFunction("add", std::function<int(int)>(std::bind_front(&add2, 10)));
- *
- * // Write:
- * ns.addFunction("add", luabridge::bind_front(&add2, 10));
- * @endcode
+ * callable's signature.
  *
  * For member function pointers the implicit object argument consumed by std::invoke is not
  * counted as part of the remaining (Lua-visible) parameter list, matching std::bind_front
@@ -672,13 +748,85 @@ auto bind_front(F&& f, BoundArgs&&... args)
     using Fn = std::decay_t<F>;
     using FnTraits = detail::function_traits<Fn>;
 
-    static constexpr std::size_t skip = FnTraits::is_member ? 1u : 0u;
+    static constexpr std::size_t skip = std::is_member_function_pointer_v<Fn> ? 1u : 0u;
     static constexpr std::size_t num_effective_bound = sizeof...(BoundArgs) - skip;
 
     using remaining = detail::tuple_drop_first_t<num_effective_bound, typename FnTraits::argument_types>;
     using R = typename FnTraits::result_type;
 
     return detail::bind_front_wrapper<R, remaining, Fn, std::decay_t<BoundArgs>...>(
+        std::forward<F>(f), std::forward<BoundArgs>(args)...);
+}
+
+//=================================================================================================
+namespace detail {
+
+/**
+ * @brief Internal storage for luabridge::bind_back — exposes a non-template operator() so that
+ *        function_traits can statically resolve result_type and argument_types.
+ *
+ *        LeadingArgsTuple is the tuple of arguments that the caller must provide; BoundArgs are
+ *        the trailing arguments captured at bind time. For member function pointers, the class
+ *        pointer is included as the first element of LeadingArgsTuple.
+ */
+template <class R, class LeadingArgsTuple, class Fn, class... BoundArgs>
+struct bind_back_wrapper;
+
+template <class R, class... Leading, class Fn, class... BoundArgs>
+struct bind_back_wrapper<R, std::tuple<Leading...>, Fn, BoundArgs...>
+{
+    Fn fn_;
+    std::tuple<BoundArgs...> bound_;
+
+    template <class F, class... BA>
+    bind_back_wrapper(F&& f, BA&&... ba)
+        : fn_(std::forward<F>(f)), bound_(std::forward<BA>(ba)...)
+    {
+    }
+
+    R operator()(Leading... args) const
+    {
+        return std::apply([&](const auto&... ba) { return std::invoke(fn_, args..., ba...); }, bound_);
+    }
+};
+
+} // namespace detail
+
+//=================================================================================================
+/**
+ * @brief Drop-in replacement for std::bind_back with statically introspectable argument types.
+ *
+ * Stores the callable and its trailing bound arguments, then exposes a concrete non-template
+ * operator() whose parameter types are derived directly from the underlying callable's signature.
+ * This lets LuaBridge register the result with addFunction / addStaticFunction without any extra
+ * annotation.
+ *
+ * For member function pointers the class pointer is automatically prepended to the remaining
+ * (Lua-visible) parameter list so that LuaBridge can dispatch it as a proxy member function.
+ *
+ * @tparam F     Callable type (function pointer, member function pointer, functor).
+ * @tparam BoundArgs Trailing argument types to bind.
+ * @param  f     The callable to wrap.
+ * @param  args  Trailing arguments forwarded into the wrapper by value.
+ * @return A callable object whose operator() accepts the remaining (leading) arguments.
+ */
+template <class F, class... BoundArgs>
+auto bind_back(F&& f, BoundArgs&&... args)
+{
+    using Fn = std::decay_t<F>;
+    using FnTraits = detail::function_traits<Fn>;
+
+    static constexpr std::size_t num_explicit = FnTraits::arity;
+    static constexpr std::size_t num_bound = sizeof...(BoundArgs);
+    static constexpr std::size_t num_remaining = num_explicit - num_bound;
+
+    using explicit_remaining = detail::tuple_take_first_t<num_remaining, typename FnTraits::argument_types>;
+
+    using leading = detail::bind_back_leading_t<Fn, explicit_remaining>;
+
+    using R = typename FnTraits::result_type;
+
+    return detail::bind_back_wrapper<R, leading, Fn, std::decay_t<BoundArgs>...>(
         std::forward<F>(f), std::forward<BoundArgs>(args)...);
 }
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set (LUABRIDGE_TEST_SOURCE_FILES
   Source/TestsMain.cpp
   Source/UnorderedMapTests.cpp
   Source/UserdataTests.cpp
+  Source/VariantTests.cpp
   Source/VectorTests.cpp
 )
 

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -840,6 +840,36 @@ int proxyCFunctionState(lua_State* L)
 
     return 1;
 }
+
+template<class T, class Base>
+T proxyFunctionWithBoundOffset(int offset, Class<T, Base>* object, T value)
+{
+    return value + offset;
+}
+
+template<class T, class Base>
+T proxyConstFunctionWithBoundOffset(int offset, const Class<T, Base>* object, T value)
+{
+    return value + offset;
+}
+
+template<class T, class Base>
+T proxyFunctionWithTrailingOffset(Class<T, Base>* object, T value, int offset)
+{
+    return value + offset;
+}
+
+template<class T, class Base>
+T proxyConstFunctionWithTrailingOffset(const Class<T, Base>* object, T value, int offset)
+{
+    return value + offset;
+}
+
+template<class T>
+T staticFunctionAdd(T a, T b)
+{
+    return a + b;
+}
 } // namespace
 
 TEST_F(ClassFunctions, ClassWithTemplateMembers)
@@ -1135,6 +1165,162 @@ TEST_F(ClassFunctions, ConstStdFunctions)
     closeLuaState(); // Force garbage collection
 
     ASSERT_TRUE(data.expired());
+}
+
+TEST_F(ClassFunctions, BindFrontProxyFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("method", luabridge::bind_front(&proxyFunctionWithBoundOffset<int, EmptyBase>, 100))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():method (5)");
+    ASSERT_EQ(105, result<int>());
+
+    runLua("result = returnConstRef ().method"); // Don't call, just get
+    ASSERT_TRUE(result().isNil());
+
+    runLua("result = returnPtr ():method (2)");
+    ASSERT_EQ(102, result<int>());
+
+    runLua("result = returnConstPtr ().method"); // Don't call, just get
+    ASSERT_TRUE(result().isNil());
+
+    runLua("result = returnValue ():method (3)");
+    ASSERT_EQ(103, result<int>());
+}
+
+TEST_F(ClassFunctions, BindFrontConstProxyFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("constMethod", luabridge::bind_front(&proxyConstFunctionWithBoundOffset<int, EmptyBase>, 200))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():constMethod (5)");
+    ASSERT_EQ(205, result<int>());
+
+    runLua("result = returnConstRef ():constMethod (10)");
+    ASSERT_EQ(210, result<int>());
+
+    runLua("result = returnPtr ():constMethod (3)");
+    ASSERT_EQ(203, result<int>());
+
+    runLua("result = returnConstPtr ():constMethod (4)");
+    ASSERT_EQ(204, result<int>());
+
+    runLua("result = returnValue ():constMethod (1)");
+    ASSERT_EQ(201, result<int>());
+}
+
+TEST_F(ClassFunctions, BindBackProxyFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("method", luabridge::bind_back(&proxyFunctionWithTrailingOffset<int, EmptyBase>, 100))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():method (5)");
+    ASSERT_EQ(105, result<int>());
+
+    runLua("result = returnConstRef ().method"); // Don't call, just get
+    ASSERT_TRUE(result().isNil());
+
+    runLua("result = returnPtr ():method (2)");
+    ASSERT_EQ(102, result<int>());
+
+    runLua("result = returnConstPtr ().method"); // Don't call, just get
+    ASSERT_TRUE(result().isNil());
+
+    runLua("result = returnValue ():method (3)");
+    ASSERT_EQ(103, result<int>());
+}
+
+TEST_F(ClassFunctions, BindBackConstProxyFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("constMethod", luabridge::bind_back(&proxyConstFunctionWithTrailingOffset<int, EmptyBase>, 200))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():constMethod (5)");
+    ASSERT_EQ(205, result<int>());
+
+    runLua("result = returnConstRef ():constMethod (10)");
+    ASSERT_EQ(210, result<int>());
+
+    runLua("result = returnPtr ():constMethod (3)");
+    ASSERT_EQ(203, result<int>());
+
+    runLua("result = returnConstPtr ():constMethod (4)");
+    ASSERT_EQ(204, result<int>());
+
+    runLua("result = returnValue ():constMethod (1)");
+    ASSERT_EQ(201, result<int>());
+}
+
+TEST_F(ClassFunctions, BindBackMemberFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("method", luabridge::bind_back(&Int::method, 7))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():method ()");
+    ASSERT_EQ(7, result<int>());
+
+    runLua("result = returnPtr ():method ()");
+    ASSERT_EQ(7, result<int>());
+
+    runLua("result = returnValue ():method ()");
+    ASSERT_EQ(7, result<int>());
+}
+
+TEST_F(ClassFunctions, BindBackConstMemberFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addFunction("constMethod", luabridge::bind_back(&Int::constMethod, 9))
+        .endClass();
+
+    addHelperFunctions(L);
+
+    runLua("result = returnRef ():constMethod ()");
+    ASSERT_EQ(9, result<int>());
+
+    runLua("result = returnConstRef ():constMethod ()");
+    ASSERT_EQ(9, result<int>());
+
+    runLua("result = returnPtr ():constMethod ()");
+    ASSERT_EQ(9, result<int>());
+
+    runLua("result = returnConstPtr ():constMethod ()");
+    ASSERT_EQ(9, result<int>());
+
+    runLua("result = returnValue ():constMethod ()");
+    ASSERT_EQ(9, result<int>());
 }
 
 struct ClassProperties : ClassTests
@@ -1789,6 +1975,64 @@ TEST_F(ClassStaticFunctions, StdFunctions)
 
     runLua("result = Int.static (Int (35))");
     ASSERT_EQ(35, result<Int>().data);
+}
+
+TEST_F(ClassStaticFunctions, BindFrontFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addStaticFunction("add", luabridge::bind_front(&staticFunctionAdd<int>, 10))
+        .endClass();
+
+    runLua("result = Int.add (32)");
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(ClassStaticFunctions, BindFrontMemberFunctionBoundObject)
+{
+    using Int = Class<int, EmptyBase>;
+
+    Int myObject(42);
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addStaticFunction("getData", luabridge::bind_front(&Int::getData, &myObject))
+        .addStaticFunction("method", luabridge::bind_front(&Int::method, &myObject))
+        .endClass();
+
+    runLua("result = Int.getData ()");
+    ASSERT_EQ(42, result<int>());
+
+    runLua("result = Int.method (7)");
+    ASSERT_EQ(7, result<int>());
+}
+
+TEST_F(ClassStaticFunctions, BindBackFunctions)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addStaticFunction("add", luabridge::bind_back(&staticFunctionAdd<int>, 10))
+        .endClass();
+
+    runLua("result = Int.add (32)");
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(ClassStaticFunctions, BindBackFunctionsFullyBound)
+{
+    using Int = Class<int, EmptyBase>;
+
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Int>("Int")
+        .addStaticFunction("getFortyTwo", luabridge::bind_back(&staticFunctionAdd<int>, 10, 32))
+        .endClass();
+
+    runLua("result = Int.getFortyTwo ()");
+    ASSERT_EQ(42, result<int>());
 }
 
 struct ClassStaticProperties : ClassTests

--- a/Tests/Source/LuaRefTests.cpp
+++ b/Tests/Source/LuaRefTests.cpp
@@ -9,6 +9,10 @@
 
 #include <sstream>
 
+namespace {
+int addInts(int a, int b) { return a + b; }
+} // namespace
+
 struct LuaRefTests : TestBase
 {
 };
@@ -911,6 +915,38 @@ TEST_F(LuaRefTests, RegisterLambdaInFunction)
 
     runLua("obj = Class(); result = takeClassState (obj, 10, 100)");
     ASSERT_EQ(1 + 10 + 100 + 3, result<int>());
+}
+
+TEST_F(LuaRefTests, RegisterBindFrontInNewFunction)
+{
+    luabridge::setGlobal(L, luabridge::newFunction(L, luabridge::bind_front(&addInts, 10)), "addTen");
+
+    runLua("result = addTen (32)");
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(LuaRefTests, RegisterBindFrontLambdaInNewFunction)
+{
+    luabridge::setGlobal(L, luabridge::newFunction(L, luabridge::bind_front([](int a, int b) { return a + b; }, 10)), "addTen");
+
+    runLua("result = addTen (32)");
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(LuaRefTests, RegisterBindBackInNewFunction)
+{
+    luabridge::setGlobal(L, luabridge::newFunction(L, luabridge::bind_back(&addInts, 10)), "addTen");
+
+    runLua("result = addTen (32)");
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(LuaRefTests, RegisterBindBackLambdaInNewFunction)
+{
+    luabridge::setGlobal(L, luabridge::newFunction(L, luabridge::bind_back([](int a, int b) { return a + b; }, 10)), "addTen");
+
+    runLua("result = addTen (32)");
+    ASSERT_EQ(42, result<int>());
 }
 
 TEST_F(LuaRefTests, HookTesting)

--- a/Tests/Source/NamespaceTests.cpp
+++ b/Tests/Source/NamespaceTests.cpp
@@ -668,6 +668,51 @@ TEST_F(NamespaceTests, StdBindFrontFunctions)
     }
 }
 
+TEST_F(NamespaceTests, BindFrontCapturingLambdas)
+{
+    int x = 30;
+
+    luabridge::getGlobalNamespace(L).addFunction("Function",
+        luabridge::bind_front([x](int offset, int v) -> int { return x + offset + v; }, 2));
+
+    runLua("result = Function (10)");
+    ASSERT_TRUE(result().isNumber());
+    ASSERT_EQ(42, result<int>());
+}
+
+TEST_F(NamespaceTests, BindBackFunctions)
+{
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function",
+            luabridge::bind_back(&Function<int>, 1));
+
+        runLua("result = Function ()");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(1, result<int>());
+    }
+
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function",
+            luabridge::bind_back(&Function2<int>, 1));
+
+        runLua("result = Function (12)");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(13, result<int>());
+    }
+}
+
+TEST_F(NamespaceTests, BindBackCapturingLambdas)
+{
+    int x = 30;
+
+    luabridge::getGlobalNamespace(L).addFunction("Function",
+        luabridge::bind_back([x](int v, int offset) -> int { return x + offset + v; }, 2));
+
+    runLua("result = Function (10)");
+    ASSERT_TRUE(result().isNumber());
+    ASSERT_EQ(42, result<int>());
+}
+
 TEST_F(NamespaceTests, CapturingLambdas)
 {
     int x = 30;

--- a/Tests/Source/NamespaceTests.cpp
+++ b/Tests/Source/NamespaceTests.cpp
@@ -588,6 +588,12 @@ T Function(T param)
     return param;
 }
 
+template<class T>
+T Function2(T param1, T param2)
+{
+    return param1 + param2;
+}
+
 int LuaFunction(lua_State* L)
 {
     lua_pushnumber(L, 42);
@@ -620,6 +626,46 @@ TEST_F(NamespaceTests, StdFunctions)
     runLua("result = Function (12)");
     ASSERT_TRUE(result().isNumber());
     ASSERT_EQ(12, result<int>());
+}
+
+TEST_F(NamespaceTests, StdBindFunctions)
+{
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function", std::bind(&Function<int>, 1));
+
+        runLua("result = Function ()");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(1, result<int>());
+    }
+
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function",
+            std::function<int(int)>(std::bind(&Function2<int>, 1, std::placeholders::_1)));
+
+        runLua("result = Function (12)");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(13, result<int>());
+    }
+}
+
+TEST_F(NamespaceTests, StdBindFrontFunctions)
+{
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function", std::bind_front(&Function<int>, 1));
+
+        runLua("result = Function ()");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(1, result<int>());
+    }
+
+    {
+        luabridge::getGlobalNamespace(L).addFunction("Function",
+            luabridge::bind_front(&Function2<int>, 1));
+
+        runLua("result = Function (12)");
+        ASSERT_TRUE(result().isNumber());
+        ASSERT_EQ(13, result<int>());
+    }
 }
 
 TEST_F(NamespaceTests, CapturingLambdas)

--- a/Tests/Source/VariantTests.cpp
+++ b/Tests/Source/VariantTests.cpp
@@ -1,0 +1,160 @@
+// https://github.com/kunitoki/LuaBridge3
+// Copyright 2026, kunitoki
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+
+#include "LuaBridge/Variant.h"
+
+#include <string>
+#include <variant>
+
+namespace {
+using TestVariant = std::variant<int, std::string>;
+
+std::string describeVariant(const TestVariant& value)
+{
+    if (const auto* intValue = std::get_if<int>(&value))
+        return "int:" + std::to_string(*intValue);
+
+    return "string:" + std::get<std::string>(value);
+}
+
+TestVariant echoVariant(const TestVariant& value)
+{
+    return value;
+}
+} // namespace
+
+struct VariantTests : TestBase
+{
+};
+
+TEST_F(VariantTests, PushIntAlternative)
+{
+    TestVariant value = 42;
+
+    ASSERT_TRUE(luabridge::push(L, value));
+
+    EXPECT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    EXPECT_EQ(42, lua_tointeger(L, -1));
+}
+
+TEST_F(VariantTests, PushStringAlternative)
+{
+    TestVariant value = std::string("hello");
+
+    ASSERT_TRUE(luabridge::push(L, value));
+
+    EXPECT_EQ(LUA_TSTRING, lua_type(L, -1));
+    EXPECT_STREQ("hello", lua_tostring(L, -1));
+}
+
+TEST_F(VariantTests, GetIntAlternative)
+{
+    lua_pushinteger(L, 42);
+
+    auto result = luabridge::Stack<TestVariant>::get(L, -1);
+
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(std::holds_alternative<int>(*result));
+    EXPECT_EQ(42, std::get<int>(*result));
+}
+
+TEST_F(VariantTests, GetStringAlternative)
+{
+    lua_pushstring(L, "hello");
+
+    auto result = luabridge::Stack<TestVariant>::get(L, -1);
+
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(std::holds_alternative<std::string>(*result));
+    EXPECT_EQ("hello", std::get<std::string>(*result));
+}
+
+TEST_F(VariantTests, GetInvalidType)
+{
+    lua_createtable(L, 0, 0);
+
+    auto result = luabridge::Stack<TestVariant>::get(L, -1);
+
+    ASSERT_FALSE(result);
+    EXPECT_EQ(luabridge::ErrorCode::InvalidTypeCast, result.error());
+}
+
+TEST_F(VariantTests, GetMonostateAlternative)
+{
+    using MaybeInt = std::variant<std::monostate, int>;
+
+    lua_pushnil(L);
+
+    auto result = luabridge::Stack<MaybeInt>::get(L, -1);
+
+    ASSERT_TRUE(result);
+    EXPECT_TRUE(std::holds_alternative<std::monostate>(*result));
+}
+
+TEST_F(VariantTests, PushMonostateAlternative)
+{
+    using MaybeInt = std::variant<std::monostate, int>;
+
+    MaybeInt value = std::monostate{};
+
+    ASSERT_TRUE(luabridge::push(L, value));
+    EXPECT_TRUE(lua_isnil(L, -1));
+}
+
+TEST_F(VariantTests, IsInstance)
+{
+    lua_pushinteger(L, 42);
+    EXPECT_TRUE(luabridge::isInstance<TestVariant>(L, -1));
+
+    lua_pop(L, 1);
+    lua_pushstring(L, "hello");
+    EXPECT_TRUE(luabridge::isInstance<TestVariant>(L, -1));
+
+    lua_pop(L, 1);
+    lua_createtable(L, 0, 0);
+    EXPECT_FALSE(luabridge::isInstance<TestVariant>(L, -1));
+}
+
+TEST_F(VariantTests, StackOverflow)
+{
+    exhaustStackSpace();
+
+    TestVariant value = 42;
+
+    ASSERT_FALSE(luabridge::push(L, value));
+}
+
+TEST_F(VariantTests, PassFromLua)
+{
+    luabridge::getGlobalNamespace(L)
+        .addFunction("describeVariant", &describeVariant);
+
+    resetResult();
+    runLua("result = describeVariant(42)");
+
+    EXPECT_EQ("int:42", result<std::string>());
+
+    resetResult();
+    runLua("result = describeVariant('hello')");
+
+    EXPECT_EQ("string:hello", result<std::string>());
+}
+
+TEST_F(VariantTests, ReturnToLua)
+{
+    luabridge::getGlobalNamespace(L)
+        .addFunction("echoVariant", &echoVariant);
+
+    resetResult();
+    runLua("result = echoVariant(42)");
+
+    EXPECT_EQ(42, result<int>());
+
+    resetResult();
+    runLua("result = echoVariant('hello')");
+
+    EXPECT_EQ("hello", result<std::string>());
+}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,15 @@ default:
 generate:
     cmake -G Xcode -B Build -DLUABRIDGE_BENCHMARKS=ON .
 
+open: generate
+    -open Build/LuaBridge.xcodeproj
+
+build: generate
+    cmake --build Build --config Debug --target LuaBridgeTests53 -j8
+
+test: build
+    ./Build/Tests/Debug/LuaBridgeTests53
+
 sanitize TYPE='address':
     cmake -G Xcode -B Build -DLUABRIDGE_SANITIZE={{TYPE}} .
 


### PR DESCRIPTION
This pull request introduces support for partial function application in LuaBridge via a new `luabridge::bind_front` utility, making it easier to register partially applied functions with automatic type deduction. The documentation and test suite have been updated accordingly, and several enhancements have been made to function trait detection and callable support.

**Enhancements to Partial Application and Function Registration:**

* Added `luabridge::bind_front`, a drop-in replacement for `std::bind_front` that allows partial application of function arguments with automatic deduction of remaining parameter types, enabling easier and more concise registration of bound functions in LuaBridge.
* Updated the documentation (`Manual.md`) to describe and provide examples for `luabridge::bind_front`, including its advantages over `std::bind_front` and usage with member functions. [[1]](diffhunk://#diff-30285cd92fd0939f0eb62dda195f7e2e011c5faf976e86ee95fb2deca76f58e7L35-R36) [[2]](diffhunk://#diff-30285cd92fd0939f0eb62dda195f7e2e011c5faf976e86ee95fb2deca76f58e7L605-R637)

**Improvements to Callable and Function Trait Detection:**

* Enhanced function trait and callable detection logic in `FuncTraits.h` to better support functors, lambdas, and objects with custom call operators, improving robustness and flexibility when registering different callable types. [[1]](diffhunk://#diff-1820fc43ac350a9900f315497557e546f93841d08e93e79419da61c95aa3f514R198-R223) [[2]](diffhunk://#diff-1820fc43ac350a9900f315497557e546f93841d08e93e79419da61c95aa3f514R240-R252) [[3]](diffhunk://#diff-1820fc43ac350a9900f315497557e546f93841d08e93e79419da61c95aa3f514R343-R348)

**Testing and Build System Updates:**

* Added new tests in `NamespaceTests.cpp` to verify correct behavior of both `std::bind_front` and `luabridge::bind_front` with various function signatures, ensuring correctness and coverage of the new feature. [[1]](diffhunk://#diff-fa0b4424f4f197d3ccd6c903da589a4014532ec91325f96b0302028a425e2907R591-R596) [[2]](diffhunk://#diff-fa0b4424f4f197d3ccd6c903da589a4014532ec91325f96b0302028a425e2907R631-R670)
* Updated the build system (`justfile`) to include convenient targets for opening the project, building, and running tests.