### PR TITLE
Fix line number not always reported

### DIFF
--- a/Source/LuaBridge/detail/CFunctions.h
+++ b/Source/LuaBridge/detail/CFunctions.h
@@ -916,7 +916,7 @@ inline std::optional<int> try_call_newindex_extensible(lua_State* L, const char*
 
             const Options options = get_class_options(L, -2);
             if (! options.test(allowOverridingMethods))
-                luaL_error(L, "immutable member '%s'", key);
+                raise_lua_error(L, "immutable member '%s'", key);
 
             rawset_super_method(L, origClassTableIndex, key); // Stack: ..., candidate_ct
             lua_pop(L, 1); // Stack: ...
@@ -991,7 +991,7 @@ inline std::optional<int> try_call_newindex_extensible(lua_State* L, const char*
 
         const Options options = get_class_options(L, -2);
         if (! options.test(allowOverridingMethods))
-            luaL_error(L, "immutable member '%s'", key);
+            raise_lua_error(L, "immutable member '%s'", key);
 
         rawset_super_method(L, -2, key); // Stack: ..., candidate_ct
         lua_pop(L, 1); // Stack: ...
@@ -1134,7 +1134,7 @@ inline int newindex_metamethod(lua_State* L)
     // Try in the property set table on the current class first.
     lua_rawgetp_x(L, -1, getPropsetKey()); // Stack: mt, propset table (ps) | nil
     if (! lua_istable(L, -1))
-        luaL_error(L, "no member named '%s'", key);
+        raise_lua_error(L, "no member named '%s'", key);
 
     lua_pushvalue(L, 2); // Stack: mt, ps, field name
     lua_rawget(L, -2); // Stack: mt, ps, setter | nil
@@ -1213,7 +1213,7 @@ inline int newindex_metamethod(lua_State* L)
     }
 
     lua_pop(L, 1); // Stack: -
-    luaL_error(L, "no writable member '%s'", key);
+    raise_lua_error(L, "no writable member '%s'", key);
     return 0;
 }
 
@@ -1234,7 +1234,7 @@ inline int newindex_metamethod_simple(lua_State* L)
             const char* key = lua_tostring(L, 2);
 
             if (! lua_istable(L, lua_upvalueindex(1)))
-                luaL_error(L, "no writable member '%s'", key);
+                raise_lua_error(L, "no writable member '%s'", key);
 
             lua_pushvalue(L, 2); // Stack: key
             lua_rawget(L, lua_upvalueindex(1)); // Stack: setter | nil
@@ -1258,7 +1258,7 @@ inline int newindex_metamethod_simple(lua_State* L)
             const char* key = lua_tostring(L, 2);
 
             if (! lua_istable(L, lua_upvalueindex(1)))
-                luaL_error(L, "no writable member '%s'", key);
+                raise_lua_error(L, "no writable member '%s'", key);
 
             lua_pushvalue(L, 2); // Stack: key
             lua_rawget(L, lua_upvalueindex(1)); // Stack: setter | nil
@@ -1270,7 +1270,7 @@ inline int newindex_metamethod_simple(lua_State* L)
                 return 0;
             }
 
-            luaL_error(L, "no writable member '%s'", key);
+            raise_lua_error(L, "no writable member '%s'", key);
         }
     }
 
@@ -1281,7 +1281,7 @@ inline int newindex_metamethod_simple(lua_State* L)
 
     lua_rawgetp_x(L, -1, getPropsetKey()); // Stack: mt, ps | nil
     if (! lua_istable(L, -1))
-        luaL_error(L, "no member named '%s'", key);
+        raise_lua_error(L, "no member named '%s'", key);
 
     lua_pushvalue(L, 2); // Stack: mt, ps, key
     lua_rawget(L, -2); // Stack: mt, ps, setter | nil
@@ -1297,7 +1297,7 @@ inline int newindex_metamethod_simple(lua_State* L)
         return 0;
     }
 
-    luaL_error(L, "no writable member '%s'", key);
+    raise_lua_error(L, "no writable member '%s'", key);
     return 0;
 }
 
@@ -2123,7 +2123,8 @@ inline int try_overload_functions(lua_State* L)
     }
     lua_concat(L, nerrors * 2 + 1);
 
-    lua_error_x(L); // throw error message just built
+    const char* message = lua_tostring(L, -1);
+    raise_lua_error(L, "%s", message ? message : "");
 }
 
 //=================================================================================================

--- a/Tests/Source/OverloadTests.cpp
+++ b/Tests/Source/OverloadTests.cpp
@@ -67,6 +67,25 @@ TEST_F(OverloadTests, NoMatchingArityWithState)
 #endif
 }
 
+TEST_F(OverloadTests, NoMatchingArgumentTypesReportsLine)
+{
+    luabridge::getGlobalNamespace(L)
+        .addFunction("test",
+            +[](int) -> int { return 1; },
+            +[](std::string) -> int { return 2; });
+
+    auto [ok, error] = runLuaCaptureError(R"(
+        local function call_test()
+            test({})
+        end
+        call_test()
+    )");
+
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(error.find("...") != std::string::npos || error.find("code") != std::string::npos);
+    EXPECT_TRUE(error.find(":3: All 2 overloads of test returned an error:") != std::string::npos);
+}
+
 TEST_F(OverloadTests, SingleArgumentOverloads)
 {
     int x = 100;


### PR DESCRIPTION
This pull request refactors error handling in the LuaBridge C++ integration by replacing direct calls to `luaL_error` and `lua_error_x` with a new helper function, `raise_lua_error`, throughout the `CFunctions.h` file. Additionally, a new test is added to improve coverage for error reporting in function overload resolution.

**Error handling improvements:**

* Replaced all instances of `luaL_error` and `lua_error_x` with `raise_lua_error` in `Source/LuaBridge/detail/CFunctions.h` to standardize and possibly enhance error reporting across metamethods and function overloads. [[1]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L919-R919) [[2]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L994-R994) [[3]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1137-R1137) [[4]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1216-R1216) [[5]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1237-R1237) [[6]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1261-R1261) [[7]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1273-R1273) [[8]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1284-R1284) [[9]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L1300-R1300) [[10]](diffhunk://#diff-a6c1434d943944028ce926611075458078b52d6d2de84188f557c344c3c0fe74L2126-R2127)

**Testing improvements:**

* Added a new unit test `NoMatchingArgumentTypesReportsLine` in `Tests/Source/OverloadTests.cpp` to verify that calling an overloaded Lua-exposed function with incorrect argument types produces a clear error message including line information.