### PR TITLE
Fix compilation

### DIFF
--- a/Distribution/LuaBridge/LuaBridge.h
+++ b/Distribution/LuaBridge/LuaBridge.h
@@ -8505,10 +8505,9 @@ inline int newindex_metamethod_simple(lua_State* L)
     return 0;
 }
 
-inline int read_only_error(lua_State* L)
+[[noreturn]] inline int read_only_error(lua_State* L)
 {
     raise_lua_error(L, "'%s' is read-only", lua_tostring(L, lua_upvalueindex(1)));
-    return 0;
 }
 
 template <class C>

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -18,13 +18,13 @@ LOCAL_INCLUDE_FILE_MATCHER = re.compile(r'#include\s*\"([\w.\\/]*)\"')
 
 GUARDED_INCLUDES = [
 	{ "header": "version" },
-	{ "header": "coroutine", "condition": "(__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L))" },
-	{ "header": "ranges", "condition": "(__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L))" },
-	{ "header": "span", "condition": "(__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L))" },
-	{ "header": "flat_map", "condition": "(__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))" },
-	{ "header": "flat_set", "condition": "(__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))" },
-	{ "header": "expected", "condition": "(__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))" },
-	{ "header": "move_only_function", "condition": "(__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))" },
+	{ "header": "coroutine", "condition": "(__cplusplus >= 202002L || (defined(_MSC_VER) && _HAS_CXX20))" },
+	{ "header": "ranges", "condition": "(__cplusplus >= 202002L || (defined(_MSC_VER) && _HAS_CXX20))" },
+	{ "header": "span", "condition": "(__cplusplus >= 202002L || (defined(_MSC_VER) && _HAS_CXX20))" },
+	{ "header": "flat_map", "condition": "(__cplusplus >= 202302L || (defined(_MSC_VER) && _HAS_CXX23))" },
+	{ "header": "flat_set", "condition": "(__cplusplus >= 202302L || (defined(_MSC_VER) && _HAS_CXX23))" },
+	{ "header": "expected", "condition": "(__cplusplus >= 202302L || (defined(_MSC_VER) && _HAS_CXX23))" },
+	{ "header": "move_only_function", "condition": "(__cplusplus >= 202302L || (defined(_MSC_VER) && _HAS_CXX23))" },
 ]
 
 def GetGuardedInclude(header):


### PR DESCRIPTION
This pull request introduces two main changes: it updates the C++ standard library include guard conditions in the `amalgamate.py` script to improve compatibility with MSVC, and it marks the `read_only_error` function in `LuaBridge.h` as `[[noreturn]]` to clarify its behavior for the compiler and readers.

**C++ Standard Library Include Guard Updates:**

* Updated the MSVC-specific conditions in `amalgamate.py` for C++20 and C++23 headers to use `_MSC_VER` and feature-test macros like `_HAS_CXX20` and `_HAS_CXX23`, improving detection of available features on MSVC.

**Code Quality and Correctness Improvements:**

* Marked the `read_only_error` function in `LuaBridge.h` as `[[noreturn]]`, indicating that the function does not return, which helps with compiler optimizations and static analysis.