### PR TITLE
Fix windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ endif()
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 
+if (MSVC AND CMAKE_CXX_STANDARD GREATER_EQUAL 23)
+    set (CMAKE_CXX23_STANDARD_COMPILE_OPTION "/std:c++latest")
+    set (CMAKE_CXX23_EXTENSION_COMPILE_OPTION "/std:c++latest")
+endif()
+
 find_program (FIND_EXECUTABLE find)
 find_program (LCOV_EXECUTABLE lcov)
 find_program (GENHTML_EXECUTABLE genhtml)

--- a/Manual.md
+++ b/Manual.md
@@ -93,8 +93,9 @@ Contents
     * [6.8 - LUABRIDGE_HAS_CXX20_SPAN / LUABRIDGE_DISABLE_CXX20_SPAN](#68---luabridge-has-cxx20-span--luabridge-disable-cxx20-span)
     * [6.9 - LUABRIDGE_HAS_CXX20_RANGES / LUABRIDGE_DISABLE_CXX20_RANGES](#69---luabridge-has-cxx20-ranges--luabridge-disable-cxx20-ranges)
     * [6.10 - LUABRIDGE_HAS_CXX23_EXPECTED / LUABRIDGE_DISABLE_CXX23_EXPECTED](#610---luabridge-has-cxx23-expected--luabridge-disable-cxx23-expected)
-    * [6.11 - LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS / LUABRIDGE_DISABLE_CXX23_FLAT_CONTAINERS](#611---luabridge-has-cxx23-flat-containers--luabridge-disable-cxx23-flat-containers)
-    * [6.12 - LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION / LUABRIDGE_DISABLE_CXX23_MOVE_ONLY_FUNCTION](#612---luabridge-has-cxx23-move-only-function--luabridge-disable-cxx23-move-only-function)
+    * [6.11 - LUABRIDGE_HAS_CXX23_FLAT_MAP / LUABRIDGE_DISABLE_CXX23_FLAT_MAP](#611---luabridge-has-cxx23-flat-map--luabridge-disable-cxx23-flat-map)
+    * [6.12 - LUABRIDGE_HAS_CXX23_FLAT_SET / LUABRIDGE_DISABLE_CXX23_FLAT_SET](#612---luabridge-has-cxx23-flat-set--luabridge-disable-cxx23-flat-set)
+    * [6.13 - LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION / LUABRIDGE_DISABLE_CXX23_MOVE_ONLY_FUNCTION](#612---luabridge-has-cxx23-move-only-function--luabridge-disable-cxx23-move-only-function)
 
 *   [Appendix - API Reference](#appendix---api-reference)
 
@@ -1463,8 +1464,8 @@ The table below lists every optional header and its requirements:
 | `LuaBridge/Any.h` | `std::any` | C++17 (`LUABRIDGE_HAS_CXX17_ANY`) | Push-only; types must be pre-registered with `luabridge::registerAnyPush<T>(L)` |
 | `LuaBridge/Span.h` | `std::span<T>` | C++20 (`LUABRIDGE_HAS_CXX20_SPAN`) | Push-only; use `std::vector<T>` to retrieve sequences from Lua |
 | `LuaBridge/StdExpected.h` | `std::expected<T,E>` | C++23 (`LUABRIDGE_HAS_CXX23_EXPECTED`) | Pushes the value on success, nil on error |
-| `LuaBridge/FlatMap.h` | `std::flat_map<K,V>` | C++23 (`LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS`) | Ordered key-value table backed by contiguous storage |
-| `LuaBridge/FlatSet.h` | `std::flat_set<K>` | C++23 (`LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS`) | Ordered set backed by contiguous storage |
+| `LuaBridge/FlatMap.h` | `std::flat_map<K,V>` | C++23 (`LUABRIDGE_HAS_CXX23_FLAT_MAP`) | Ordered key-value table backed by contiguous storage |
+| `LuaBridge/FlatSet.h` | `std::flat_set<K>` | C++23 (`LUABRIDGE_HAS_CXX23_FLAT_SET`) | Ordered set backed by contiguous storage |
 
 `std::filesystem::path` is also supported as a built-in type when C++17 filesystem is available (`LUABRIDGE_HAS_CXX17_FILESYSTEM`). It is converted to and from a Lua string automatically; no additional header is required beyond `LuaBridge/LuaBridge.h`.
 
@@ -2530,21 +2531,35 @@ To force the feature off:
 #include <LuaBridge/LuaBridge.h>
 ```
 
-6.11 - LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS / LUABRIDGE_DISABLE_CXX23_FLAT_CONTAINERS
+6.11 - LUABRIDGE_HAS_CXX23_FLAT_MAP / LUABRIDGE_DISABLE_CXX23_FLAT_MAP
 -------------------------------------------------------------------------------------
 
-**`LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS` - auto-detected when C++23 is enabled, override allowed**
+**`LUABRIDGE_HAS_CXX23_FLAT_MAP` - auto-detected when C++23 is enabled, override allowed**
 
-When a C++23 compiler and `<flat_map>` are available, LuaBridge enables conversion support for `std::flat_map` and `std::flat_set` via `LuaBridge/FlatMap.h` and `LuaBridge/FlatSet.h` respectively. These are contiguous-storage analogues of `std::map` and `std::set` with identical Lua table semantics.
+When a C++23 compiler and `<flat_map>` are available, LuaBridge enables conversion support for `std::flat_map` via `LuaBridge/FlatMap.h`. This is a contiguous-storage analogue of `std::map` with identical Lua table semantics.
 
 To force the feature off:
 
 ```cpp
-#define LUABRIDGE_DISABLE_CXX23_FLAT_CONTAINERS
+#define LUABRIDGE_DISABLE_CXX23_FLAT_MAP
 #include <LuaBridge/LuaBridge.h>
 ```
 
-6.12 - LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION / LUABRIDGE_DISABLE_CXX23_MOVE_ONLY_FUNCTION
+6.12 - LUABRIDGE_HAS_CXX23_FLAT_SET / LUABRIDGE_DISABLE_CXX23_FLAT_SET
+-------------------------------------------------------------------------------------
+
+**`LUABRIDGE_HAS_CXX23_FLAT_SET` - auto-detected when C++23 is enabled, override allowed**
+
+When a C++23 compiler and `<flat_set>` are available, LuaBridge enables conversion support for `std::flat_set` via `LuaBridge/FlatSet.h`. This is a contiguous-storage analogue of `std::set` with identical Lua table semantics.
+
+To force the feature off:
+
+```cpp
+#define LUABRIDGE_DISABLE_CXX23_FLAT_SET
+#include <LuaBridge/LuaBridge.h>
+```
+
+6.13 - LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION / LUABRIDGE_DISABLE_CXX23_MOVE_ONLY_FUNCTION
 -------------------------------------------------------------------------------------------
 
 **`LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION` - auto-detected when C++23 is enabled, override allowed**

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ LuaBridge3 auto-detects available C++ standard library features and activates th
 | `LUABRIDGE_HAS_CXX20_RANGES` | `Iterator`/`Range` satisfy `std::ranges` concepts | C++20 |
 | `LUABRIDGE_HAS_CXX20_COROUTINES` | `CppCoroutine<R>` / `LuaCoroutine` | C++20 |
 | `LUABRIDGE_HAS_CXX23_EXPECTED` | `std::expected<T,E>` conversion | C++23 |
-| `LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS` | `std::flat_map` / `std::flat_set` | C++23 |
+| `LUABRIDGE_HAS_CXX23_FLAT_MAP` | `std::flat_map` | C++23 |
+| `LUABRIDGE_HAS_CXX23_FLAT_SET` | `std::flat_set` | C++23 |
 | `LUABRIDGE_HAS_CXX23_MOVE_ONLY_FUNCTION` | `std::move_only_function` as callable | C++23 |
 
 ## Documentation

--- a/Source/LuaBridge/FlatMap.h
+++ b/Source/LuaBridge/FlatMap.h
@@ -6,7 +6,7 @@
 
 #include "detail/Stack.h"
 
-#if LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#if LUABRIDGE_HAS_CXX23_FLAT_MAP
 
 #include <flat_map>
 
@@ -86,4 +86,4 @@ struct Stack<std::flat_map<K, V, Compare, KeyContainer, MappedContainer>>
 
 } // namespace luabridge
 
-#endif // LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#endif // LUABRIDGE_HAS_CXX23_FLAT_MAP

--- a/Source/LuaBridge/FlatSet.h
+++ b/Source/LuaBridge/FlatSet.h
@@ -6,7 +6,7 @@
 
 #include "detail/Stack.h"
 
-#if LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#if LUABRIDGE_HAS_CXX23_FLAT_SET
 
 #include <flat_set>
 
@@ -81,4 +81,4 @@ struct Stack<std::flat_set<K, Compare, Container>>
 
 } // namespace luabridge
 
-#endif // LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#endif // LUABRIDGE_HAS_CXX23_FLAT_SET

--- a/Source/LuaBridge/detail/Config.h
+++ b/Source/LuaBridge/detail/Config.h
@@ -230,16 +230,30 @@
 #endif
 
 /**
- * @brief Enable C++23 flat containers library support.
+ * @brief Enable C++23 flat map library support.
  *
  * Requires C++23 and the flat_map header to be available.
- * Define LUABRIDGE_DISABLE_CXX23_FLAT_CONTAINERS to force-disable even when available.
+ * Define LUABRIDGE_DISABLE_CXX23_FLAT_MAP to force-disable even when available.
  */
-#if !defined(LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS)
-#if !defined(LUABRIDGE_DISABLE_CXX23_FLAT_CONTAINERS) && LUABRIDGE_CXX23_OR_GREATER && __has_include(<flat_map>) && __has_include(<flat_set>) && defined(__cpp_lib_flat_map)
-#define LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS 1
+#if !defined(LUABRIDGE_HAS_CXX23_FLAT_MAP)
+#if !defined(LUABRIDGE_DISABLE_CXX23_FLAT_MAP) && LUABRIDGE_CXX23_OR_GREATER && __has_include(<flat_map>) && defined(__cpp_lib_flat_map)
+#define LUABRIDGE_HAS_CXX23_FLAT_MAP 1
 #else
-#define LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS 0
+#define LUABRIDGE_HAS_CXX23_FLAT_MAP 0
+#endif
+#endif
+
+/**
+ * @brief Enable C++23 flat set library support.
+ *
+ * Requires C++23 and the flat_set header to be available.
+ * Define LUABRIDGE_DISABLE_CXX23_FLAT_SET to force-disable even when available.
+ */
+#if !defined(LUABRIDGE_HAS_CXX23_FLAT_SET)
+#if !defined(LUABRIDGE_DISABLE_CXX23_FLAT_SET) && LUABRIDGE_CXX23_OR_GREATER && __has_include(<flat_set>) && defined(__cpp_lib_flat_set)
+#define LUABRIDGE_HAS_CXX23_FLAT_SET 1
+#else
+#define LUABRIDGE_HAS_CXX23_FLAT_SET 0
 #endif
 #endif
 

--- a/Source/LuaBridge/detail/FuncTraits.h
+++ b/Source/LuaBridge/detail/FuncTraits.h
@@ -227,7 +227,7 @@ struct functor_traits_impl
 };
 
 template <class F>
-struct functor_traits_impl<F, std::enable_if_t<has_call_operator_v<F>>> : function_traits_impl<decltype(&F::operator()), true>
+struct functor_traits_impl<F, std::enable_if_t<has_call_operator_v<F> && !is_move_only_function_v<F>>> : function_traits_impl<decltype(&F::operator()), true>
 {
 };
 

--- a/Tests/Source/FlatMapTests.cpp
+++ b/Tests/Source/FlatMapTests.cpp
@@ -6,7 +6,7 @@
 
 #include "LuaBridge/FlatMap.h"
 
-#if LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#if LUABRIDGE_HAS_CXX23_FLAT_MAP
 
 #include <flat_map>
 #include <string>
@@ -168,21 +168,21 @@ TEST_F(FlatMapTests, PassToFunction)
            "end");
 
     auto foo = luabridge::getGlobal(L, "foo");
-    using Int2Bool = std::flat_map<int, bool>;
+    using Int2String = std::flat_map<int, std::string>;
 
     resetResult();
 
-    Int2Bool lvalue{{10, false}, {20, true}, {30, true}};
+    Int2String lvalue{{10, "1"}, {20, "2"}, {30, "3"}};
     ASSERT_TRUE(foo.call(lvalue));
     ASSERT_TRUE(result().isTable());
-    ASSERT_EQ(lvalue, result<Int2Bool>());
+    ASSERT_EQ(lvalue, result<Int2String>());
 
     resetResult();
 
-    const Int2Bool constLvalue = lvalue;
+    const Int2String constLvalue = lvalue;
     ASSERT_TRUE(foo.call(constLvalue));
     ASSERT_TRUE(result().isTable());
-    ASSERT_EQ(constLvalue, result<Int2Bool>());
+    ASSERT_EQ(constLvalue, result<Int2String>());
 }
 
 TEST_F(FlatMapTests, PassFromLua)
@@ -295,4 +295,4 @@ TEST_F(FlatMapTests, PushUnregisteredWithNoExceptionsShouldFailButRestoreStack)
 }
 #endif
 
-#endif // LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#endif // LUABRIDGE_HAS_CXX23_FLAT_MAP

--- a/Tests/Source/FlatSetTests.cpp
+++ b/Tests/Source/FlatSetTests.cpp
@@ -6,7 +6,7 @@
 
 #include "LuaBridge/FlatSet.h"
 
-#if LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#if LUABRIDGE_HAS_CXX23_FLAT_SET
 
 #include <flat_set>
 #include <string>
@@ -257,4 +257,4 @@ TEST_F(FlatSetTests, PushUnregisteredWithNoExceptionsShouldFailButRestoreStack)
 }
 #endif
 
-#endif // LUABRIDGE_HAS_CXX23_FLAT_CONTAINERS
+#endif // LUABRIDGE_HAS_CXX23_FLAT_SET


### PR DESCRIPTION
This pull request refactors and improves the handling of C++23 flat containers in LuaBridge. Instead of a single macro for both `std::flat_map` and `std::flat_set`, it introduces separate feature macros and configuration logic for each container. The documentation, source, and tests are updated to reflect this change and provide more granular control and clarity.

**Build system and configuration improvements:**

* Added MSVC-specific C++23 standard compile options in `CMakeLists.txt` to ensure correct standard selection on Visual Studio compilers.
* Split the feature detection macros in `Config.h` into `LUABRIDGE_HAS_CXX23_FLAT_MAP` and `LUABRIDGE_HAS_CXX23_FLAT_SET`, each with independent detection and disable macros.

**Source code updates:**

* Updated `FlatMap.h` and `FlatSet.h` to use their respective new macros for conditional compilation, improving clarity and maintainability. [[1]](diffhunk://#diff-021bb72f6aee4b8797e44388ce69c95fbcc87f8faa3c3b12a6d96813f9fb74f1L9-R9) [[2]](diffhunk://#diff-021bb72f6aee4b8797e44388ce69c95fbcc87f8faa3c3b12a6d96813f9fb74f1L89-R89) [[3]](diffhunk://#diff-15293ed685ce397417339daca8a0063798e28cd4c2b109661694ea1ce725bec9L9-R9) [[4]](diffhunk://#diff-15293ed685ce397417339daca8a0063798e28cd4c2b109661694ea1ce725bec9L84-R84)
* Adjusted tests in `FlatMapTests.cpp` and `FlatSetTests.cpp` to use the new macros, and improved the `PassToFunction` test to use a more meaningful type (`std::flat_map<int, std::string>`). [[1]](diffhunk://#diff-acc147bb7aa4d9521a1899b09ce488aea14dbb0f5ffe0021246b1d432172356fL9-R9) [[2]](diffhunk://#diff-acc147bb7aa4d9521a1899b09ce488aea14dbb0f5ffe0021246b1d432172356fL171-R185) [[3]](diffhunk://#diff-acc147bb7aa4d9521a1899b09ce488aea14dbb0f5ffe0021246b1d432172356fL298-R298) [[4]](diffhunk://#diff-3d6fab8a9358bb5e3cfcb7e34a80edb2ee16c6ed43247826c7f2476939b088dfL9-R9) [[5]](diffhunk://#diff-3d6fab8a9358bb5e3cfcb7e34a80edb2ee16c6ed43247826c7f2476939b088dfL260-R260)
* Fixed a subtle bug in `FuncTraits.h` so that move-only functions are not incorrectly detected as regular functors.

**Documentation updates:**

* Updated `README.md` and `Manual.md` to document the new macros and explain the separate support for `std::flat_map` and `std::flat_set`, including how to enable/disable each feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R147) [[2]](diffhunk://#diff-30285cd92fd0939f0eb62dda195f7e2e011c5faf976e86ee95fb2deca76f58e7L96-R98) [[3]](diffhunk://#diff-30285cd92fd0939f0eb62dda195f7e2e011c5faf976e86ee95fb2deca76f58e7L1466-R1468) [[4]](diffhunk://#diff-30285cd92fd0939f0eb62dda195f7e2e011c5faf976e86ee95fb2deca76f58e7L2533-R2562)